### PR TITLE
[EDA-1520] - delete set_character_when_move

### DIFF
--- a/game/cell.py
+++ b/game/cell.py
@@ -19,12 +19,6 @@ class Cell():
     def are_there_player(self) -> bool:
         return self.character is not None
 
-    # TODO: refactor method
-    def set_character_when_move(self, character):
-        self.character = character
-        self.gold = character.golds
-        self.diamond = character.diamonds
-
     @property
     def has_player(self):
         return self.character.player.name if (

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -65,19 +65,6 @@ class TestCell(unittest.TestCase):
 
         self.assertEqual(cell.empty, expected)
 
-    @parameterized.expand([  # cell set_character_when_move
-        (PLAYER_1, 1, 3),
-        (PLAYER_2, 0, 4)
-    ])
-    def test_cell_set_character_when_move(self, player_name, diamond, gold):
-        cell = Cell(0, 0)
-        character = Character(Player(player_name))
-        character.diamonds = diamond
-        character.golds = gold
-        cell.set_character_when_move(character)
-        self.assertEqual(cell.diamond, character.diamonds)
-        self.assertEqual(cell.gold, character.golds)
-
     @parameterized.expand([
         (0, 0, Player(PLAYER_1), True),
         (0, 0, None, False),


### PR DESCRIPTION
Delete set_character_when_move in cell class, because the move is done with other methods of game class and because when a character moves in a cell, the cell does not get the gold and diamond's character. Those items move with the character. 