### PR TITLE
[PATCH][EDA-1527] - Migrate move action to Board class from Game class

### DIFF
--- a/constans/scenarios.py
+++ b/constans/scenarios.py
@@ -167,34 +167,41 @@ TESTED_CELL_9.is_discover[0] = True
 TESTED_CELL_10 = Cell(0, 0)
 TESTED_CELL_10.arrow = 1
 
-FILTER_MOVE_BOARD_H = [
-    [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
-FILTER_MOVE_BOARD_H[5][5].has_hole = True
-player_1 = Player(PLAYER_1)
-character_player_1 = Character(player_1)
-character_player_1.treasures.append(Gold())
-character_player_1.treasures.append(Gold())
-character_player_1.treasures.append(Gold())
-character_player_1.treasures.append(Gold())
-character_player_1.treasures.append(Gold())
-character_player_1.treasures.append(Diamond())
-FILTER_MOVE_BOARD_H[5][4].character = character_player_1
 
-FIN_FILTER_MOVE_BOARD_H = [
-    [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
-FIN_FILTER_MOVE_BOARD_H[5][5].has_hole = True
-FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
-FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
-FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
-FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
-FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
-FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Diamond())
+def filter_move_board_h():
+    FILTER_MOVE_BOARD_H = [
+        [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+    FILTER_MOVE_BOARD_H[5][5].has_hole = True
+    player_1 = Player(PLAYER_1)
+    character_player_1 = Character(player_1)
+    character_player_1.treasures.append(Gold())
+    character_player_1.treasures.append(Gold())
+    character_player_1.treasures.append(Gold())
+    character_player_1.treasures.append(Gold())
+    character_player_1.treasures.append(Gold())
+    character_player_1.treasures.append(Diamond())
+    FILTER_MOVE_BOARD_H[5][4].character = character_player_1
+    return FILTER_MOVE_BOARD_H
+
+
+def fin_filter_move_board_h():
+    FIN_FILTER_MOVE_BOARD_H = [
+        [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+    FIN_FILTER_MOVE_BOARD_H[5][5].has_hole = True
+    FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
+    FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
+    FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
+    FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
+    FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Gold())
+    FIN_FILTER_MOVE_BOARD_H[5][4].treasures.append(Diamond())
+    return FIN_FILTER_MOVE_BOARD_H
+
 
 DICTIONARY_H = {"from_row": 5,
                 "from_col": 4,
                 "to_row": 5,
                 "to_col": 5,
-                "player": PLAYER_1}
+                "player": Player(PLAYER_1)}
 
 FILTER_MOVE_SAME_P = [
     [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
@@ -247,73 +254,88 @@ DICTIONARY_ENE = {"from_row": 5,
                   "from_col": 4,
                   "to_row": 5,
                   "to_col": 5,
-                  "player": PLAYER_1}
+                  "player": Player(PLAYER_1)}
 
 DICTIONARY_MAK_MOV = {"from_row": 5,
                       "from_col": 4,
                       "to_row": 5,
                       "to_col": 5,
-                      "player": PLAYER_1}
+                      "player": Player(PLAYER_1)}
 
-MAKE_MOVE_BOARD = [
-    [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
-player_1 = Player(PLAYER_1)
-player_1.arrows = 1
-character_player_1 = Character(player_1)
-character_player_1.treasures = [Gold(), Gold()]
-MAKE_MOVE_BOARD[5][4].character = character_player_1
-MAKE_MOVE_BOARD[5][5].arrow = 1
-MAKE_MOVE_BOARD[5][5].treasures.append(Gold())
+
+def make_move_board():
+    MAKE_MOVE_BOARD = [
+        [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+    player_1 = Player(PLAYER_1)
+    player_1.arrows = 1
+    character_player_1 = Character(player_1)
+    character_player_1.treasures = [Gold(), Gold()]
+    MAKE_MOVE_BOARD[5][4].character = character_player_1
+    MAKE_MOVE_BOARD[5][5].arrow = 1
+    MAKE_MOVE_BOARD[5][5].treasures.append(Gold())
+    return MAKE_MOVE_BOARD
+
 
 DICTIONARY_MAK_MOV_P2 = {"from_row": 5,
                          "from_col": 4,
                          "to_row": 5,
                          "to_col": 5,
-                         "player": PLAYER_2}
+                         "player": Player(PLAYER_2)}
 
-MAKE_MOVE_BOARD_P2 = [
-    [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
-player_2 = Player(PLAYER_2)
-player_2.arrows = 3
-character_player_2 = Character(player_2)
-character_player_2.treasures.append(Gold())
-character_player_2.treasures.append(Gold())
-MAKE_MOVE_BOARD_P2[5][4].character = character_player_2
-MAKE_MOVE_BOARD_P2[5][5].arrow = 0
-MAKE_MOVE_BOARD_P2[5][5].treasures.append(Gold())
-MAKE_MOVE_BOARD_P2[5][5].treasures.append(Gold())
-MAKE_MOVE_BOARD_P2[5][5].treasures.append(Gold())
-MAKE_MOVE_BOARD_P2[5][5].treasures.append(Diamond())
+
+def make_move_board_p2():
+    MAKE_MOVE_BOARD_P2 = [
+        [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+    player_2 = Player(PLAYER_2)
+    player_2.arrows = 3
+    character_player_2 = Character(player_2)
+    character_player_2.treasures.append(Gold())
+    character_player_2.treasures.append(Gold())
+    MAKE_MOVE_BOARD_P2[5][4].character = character_player_2
+    MAKE_MOVE_BOARD_P2[5][5].arrow = 0
+    MAKE_MOVE_BOARD_P2[5][5].treasures.append(Gold())
+    MAKE_MOVE_BOARD_P2[5][5].treasures.append(Gold())
+    MAKE_MOVE_BOARD_P2[5][5].treasures.append(Gold())
+    MAKE_MOVE_BOARD_P2[5][5].treasures.append(Diamond())
+    return MAKE_MOVE_BOARD_P2
+
 
 DICT_FILTER_MOVE_MK = {"from_row": 5,
                        "from_col": 4,
                        "to_row": 5,
                        "to_col": 5,
-                       "player": PLAYER_2}
+                       "player": Player(PLAYER_2)}
 
-FILTER_MOVE_MAKE_MOVE = [
-    [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
-player_2 = Player(PLAYER_2)
-player_2.arrows = 3
-character_player_2 = Character(player_2)
-character_player_2.treasures.append(Gold())
-character_player_2.treasures.append(Gold())
-FILTER_MOVE_MAKE_MOVE[5][4].character = character_player_2
-FILTER_MOVE_MAKE_MOVE[5][5].arrow = 0
-FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
-FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
-FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
-FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
-FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Diamond())
 
-FIN_FILTER_MOVE_MAKE_MOVE = [
-    [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
-player_2 = Player(PLAYER_2)
-player_2.arrows = 3
-character_player_2 = Character(player_2)
-character_player_2.treasures.append(Gold())
-character_player_2.treasures.append(Gold())
-FILTER_MOVE_MAKE_MOVE[5][5].character = character_player_2
+def filter_move_make_move():
+    FILTER_MOVE_MAKE_MOVE = [
+        [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+    player_2 = Player(PLAYER_2)
+    player_2.arrows = 3
+    character_player_2 = Character(player_2)
+    character_player_2.treasures.append(Gold())
+    character_player_2.treasures.append(Gold())
+    FILTER_MOVE_MAKE_MOVE[5][4].character = character_player_2
+    FILTER_MOVE_MAKE_MOVE[5][5].arrow = 0
+    FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
+    FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
+    FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
+    FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Gold())
+    FILTER_MOVE_MAKE_MOVE[5][5].treasures.append(Diamond())
+    return FILTER_MOVE_MAKE_MOVE
+
+
+def fin_filter_move_make_move():
+    FIN_FILTER_MOVE_MAKE_MOVE = [
+        [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+    player_2 = Player(PLAYER_2)
+    player_2.arrows = 3
+    character_player_2 = Character(player_2)
+    character_player_2.treasures.append(Gold())
+    character_player_2.treasures.append(Gold())
+    FIN_FILTER_MOVE_MAKE_MOVE[5][5].character = character_player_2
+    return FIN_FILTER_MOVE_MAKE_MOVE
+
 
 PARSE_CELL_SCENARIO = [
     [Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -21,11 +21,24 @@ from constans.constants_game import (
 )
 from constans.scenarios import (
     CLOSED_GOLD_BOARD,
+    DICT_FILTER_MOVE_MK,
+    DICTIONARY_ENE,
+    DICTIONARY_H,
+    DICTIONARY_MAK_MOV,
+    DICTIONARY_MAK_MOV_P2,
+    FILTER_MOVE_BOARD_ENE,
+    filter_move_board_h,
+    filter_move_make_move,
+    FIN_FILTER_MOVE_BOARD_ENE,
+    fin_filter_move_board_h,
+    fin_filter_move_make_move,
     FIND_GOLD_POS_1,
     FIND_GOLD_POS_2,
     FIND_GOLD_POS_3,
     FIND_GOLD_POS_4,
     INITIAL_BIG_FAIL_BOARD,
+    make_move_board,
+    make_move_board_p2,
     RECURSIVE,
     RECURSIVE_SIDE,
     RECURSIVE_SIDE_CORNER,
@@ -47,7 +60,10 @@ from constans.constants_utils import (
 )
 from exceptions.personal_exceptions import (
     friendlyFireException,
+    moveToYourOwnCharPositionException,
     noArrowsAvailableException,
+    noPossibleMoveException,
+    notYourCharacterException,
     shootOutOfBoundsException,
 )
 from game.character import Character
@@ -464,3 +480,314 @@ class TestBoard(unittest.TestCase):
         board = patched_game()
         board._board = deepcopy(VALID_HOLE_SCENARIO)
         self.assertEqual(board._valid_hole(row, col), expected)
+
+    @parameterized.expand([  # case for filter event
+        (DICTIONARY_H, filter_move_board_h(),
+         fin_filter_move_board_h(), [
+            Gold(), Gold(), Gold(), Gold(), Gold(), Diamond()
+            ], 5, 1),
+        (DICTIONARY_ENE, FILTER_MOVE_BOARD_ENE,
+         FIN_FILTER_MOVE_BOARD_ENE, [
+            Gold(), Gold(), Gold(), Gold(), Gold(), Diamond()
+            ], 5, 1),
+        (DICT_FILTER_MOVE_MK, filter_move_make_move(),
+         fin_filter_move_make_move(), [], 0, 0)
+    ])
+    def test_filter_move(self, dictionary, initial_board,
+                         finalboard, treasure, count_gold, count_diam):
+        board = Board()
+        board._board = initial_board
+        board.filter_move(dictionary)
+        cell = finalboard[dictionary["from_row"]][dictionary["from_col"]]
+        cell.treasures = treasure
+        gold_cel = cell.gold
+        diam_cel = cell.diamond
+        diam_char = cell.character
+        self.assertEqual(gold_cel, count_gold)
+        self.assertEqual(diam_cel, count_diam)
+        self.assertIsNone(diam_char)
+
+    @parameterized.expand([  # verify new cell is discovered
+         (DICTIONARY_MAK_MOV, make_move_board(),
+          True, False),
+    ])
+    def test_make_move_P1_new_cell_is_discovered(
+        self, dictionary,
+        initial_board,
+        is_visited_p1,
+        is_visited_p2,
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+        new_cell: Cell = board._board[
+            dictionary["to_row"]][dictionary["to_col"]]
+        self.assertEqual(new_cell.is_discover[0], is_visited_p1)
+        self.assertEqual(new_cell.is_discover[1], is_visited_p2)
+
+    @parameterized.expand([  # verify new cell objects
+         (DICTIONARY_MAK_MOV, make_move_board(), 0, 0, 0),
+    ])
+    def test_make_move_P1_new_cell_objects(
+        self, dictionary,
+        initial_board,
+        gold_old,
+        diamond_old,
+        old_arrow
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+
+        new_cell: Cell = board._board[
+            dictionary["to_row"]][dictionary["to_col"]]
+        self.assertEqual(new_cell.arrow, old_arrow)
+        self.assertEqual(new_cell.gold, gold_old)
+        self.assertEqual(new_cell.diamond, diamond_old)
+
+    @parameterized.expand([  # verify old cell objects
+         (DICTIONARY_MAK_MOV, make_move_board(),
+          0, 0, 0),
+    ])
+    def test_make_move_P1_old_cell_objects(
+        self, dictionary,
+        initial_board,
+        gold_old,
+        diamond_old,
+        old_arrow
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+        old_cell: Cell = board._board[
+            dictionary["from_row"]][dictionary["from_col"]]
+        self.assertEqual(old_cell.arrow, old_arrow)
+        self.assertEqual(old_cell.gold, gold_old)
+        self.assertEqual(old_cell.diamond, diamond_old)
+
+    @parameterized.expand([  # verify player 1 objects
+         (DICTIONARY_MAK_MOV, make_move_board(),
+          3, 0, 2),
+    ])
+    def test_make_move_P1_player_objects(
+        self, dictionary,
+        initial_board,
+        gold_new,
+        diamond_new,
+        new_arrows,
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+        player_character: Character = board.\
+            _board[dictionary["to_row"]][dictionary["to_col"]].character
+        self.assertIsNotNone(player_character)
+        self.assertEqual(player_character.gold, gold_new)
+        self.assertEqual(player_character.diamond, diamond_new)
+        self.assertEqual(player_character.player.arrows, new_arrows)
+
+    @parameterized.expand([  # verify new cell is discovered
+         (DICTIONARY_MAK_MOV_P2, make_move_board_p2(), False, True)
+    ])
+    def test_make_move_P2_new_cell_is_discoverd(
+        self,
+        dictionary,
+        initial_board,
+        is_visited_p1,
+        is_visited_p2,
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+
+        new_cell: Cell = board._board[
+            dictionary["to_row"]][dictionary["to_col"]]
+
+        self.assertEqual(new_cell.is_discover[0], is_visited_p1)
+        self.assertEqual(new_cell.is_discover[1], is_visited_p2)
+
+    @parameterized.expand([  # verify new cell objects
+         (DICTIONARY_MAK_MOV_P2, make_move_board_p2(), 0, 0, 0)
+    ])
+    def test_make_move_P2_new_cell_objects(
+        self,
+        dictionary,
+        initial_board,
+        gold_old,
+        diamond_old,
+        old_arrow
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+
+        new_cell: Cell = board._board[
+            dictionary["to_row"]][dictionary["to_col"]]
+        self.assertEqual(new_cell.arrow, old_arrow)
+        self.assertEqual(new_cell.gold, gold_old)
+        self.assertEqual(new_cell.diamond, diamond_old)
+
+    @parameterized.expand([  # verify old cell objects
+         (DICTIONARY_MAK_MOV_P2, make_move_board_p2(), 0, 0, 0)
+    ])
+    def test_make_move_P2_old_cell_objects(
+        self,
+        dictionary,
+        initial_board,
+        gold_old,
+        diamond_old,
+        old_arrow
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+        old_cell: Cell = board._board[
+            dictionary["from_row"]][dictionary["from_col"]]
+        self.assertEqual(old_cell.arrow, old_arrow)
+        self.assertEqual(old_cell.gold, gold_old)
+        self.assertEqual(old_cell.diamond, diamond_old)
+
+    @parameterized.expand([  # verify Player 2 objects
+         (DICTIONARY_MAK_MOV_P2, make_move_board_p2(),
+          5, 1, 3)
+    ])
+    def test_make_move_P2_player_objects(
+        self,
+        dictionary,
+        initial_board,
+        gold_new,
+        diamond_new,
+        new_arrows,
+    ):
+        board = Board()
+        board._board = initial_board
+        board.make_move(dictionary)
+        player_character: Character = board.\
+            _board[dictionary["to_row"]][dictionary["to_col"]].character
+
+        self.assertIsNotNone(player_character)
+        self.assertEqual(player_character.gold, gold_new)
+        self.assertEqual(player_character.diamond, diamond_new)
+        self.assertEqual(player_character.player.arrows, new_arrows)
+
+    @parameterized.expand([  # verify string returned for Player 1
+         (DICTIONARY_MAK_MOV, make_move_board(), CORRECT_MOVE)
+    ])
+    def test_make_move_P1_string_returned(
+        self,
+        dictionary,
+        initial_board,
+        expected_result,
+    ):
+        board = Board()
+        board._board = initial_board
+        result = board.make_move(dictionary)
+        self.assertEqual(result, expected_result)
+
+    @parameterized.expand([  # verify string returned for Player 2
+         (DICTIONARY_MAK_MOV_P2, make_move_board_p2(), CORRECT_MOVE)
+    ])
+    def test_make_move_P2_string_returned(
+        self,
+        dictionary,
+        initial_board,
+        expected_result,
+    ):
+        board = Board()
+        board._board = initial_board
+        result = board.make_move(dictionary)
+        self.assertEqual(result, expected_result)
+
+    @parameterized.expand([
+        (PLAYER_1, PLAYER_2, 0, 0, 0, 1)
+    ])
+    def test_is_valid_move_not_your_character(self, p1, p2,
+                                              from_row, from_col,
+                                              to_row, to_col):
+        board = Board()
+        player_1 = Player(p1)
+        player_2 = Player(p2)
+        character_1_of_player_1 = player_1.characters[0]
+        board._board[from_row][from_col].character = character_1_of_player_1
+        # try to move a character that is not yours, current player is Player 2
+        # and try to move characters from player 1
+        with self.assertRaises(notYourCharacterException):
+            board.is_valid_move(
+                from_row,
+                from_col,
+                to_row,
+                to_col,
+                player_2)
+
+    @parameterized.expand([
+        (PLAYER_1, 0, 0, -1, 0),
+        (PLAYER_1, 0, 0, 3, 0),
+        (PLAYER_1, 0, 0, 0, 0),
+    ])
+    def test_is_valid_move_not_possible_move(self, p1,
+                                             from_row, from_col,
+                                             to_row, to_col):
+        board = Board()
+        player_1 = Player(p1)
+        character_1_of_player_1 = player_1.characters[0]
+        board._board[from_row][from_col].character = character_1_of_player_1
+        with self.assertRaises(noPossibleMoveException):
+            board.is_valid_move(
+                from_row,
+                from_col,
+                to_row,
+                to_col,
+                player_1)
+
+    @parameterized.expand([
+        (PLAYER_1, 0, 0, 0, 1),
+    ])
+    def test_is_valid_move_to_a_same_character(self, P1, from_row, from_col,
+                                               to_row, to_col):
+        board = Board()
+        player_1 = Player(P1)
+        character_1_of_player_1 = player_1.characters[0]
+        character_2_of_player_1 = player_1.characters[1]
+        board._board[from_row][from_col].character = character_1_of_player_1
+        board._board[to_row][to_col].character = character_2_of_player_1
+        with self.assertRaises(moveToYourOwnCharPositionException):
+            board.is_valid_move(
+                from_row,
+                from_col,
+                to_row,
+                to_col,
+                player_1
+            )
+
+    @parameterized.expand([
+        (PLAYER_1, 0, 0, PLAYER_2, 0, 1, 0, 1, {
+                'from_row': 0,
+                'from_col': 0,
+                'to_row': 0,
+                'to_col': 1,
+            }),
+    ])
+    def test_is_valid_move_good_move(self, P1, c1_row, c1_col, P2, c2_row,
+                                     c2_col, to_row, to_col, _expected_result):
+        expected_result = _expected_result
+        board = Board()
+        player_1 = Player(P1)
+        player_2 = Player(P2)
+        character_1_of_player_1 = player_1.characters[0]
+        character_1_of_player_2 = player_2.characters[0]
+        board._board[c1_row][c1_col].character = character_1_of_player_1
+        board._board[c2_row][c2_col].character = character_1_of_player_2
+        expected_result['player'] = player_1
+        board.filter_move = MagicMock()
+        board.is_valid_move(
+            c1_row,
+            c1_col,
+            to_row,
+            to_col,
+            player_1)
+        board.filter_move.assert_called_once()
+        board.filter_move.assert_called_once_with(expected_result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -109,3 +109,7 @@ class TestCell(unittest.TestCase):
     ])
     def test_cell_representation(self, player, cell: Cell, expected):
         self.assertEqual(cell.to_str(player), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -28,14 +28,14 @@ from game.character import Character
 from game.gold import Gold
 from game.player import Player
 from constans.constants_scores import (
+    ARROW_MISS,
     CORRECT_MOVE,
     DEATH,
-    INVALID_MOVE,
-    ARROW_MISS,
     GET_ITEMS,
+    INVALID_MOVE,
     KILL,
-    TIMEOUT,
     SCORES,
+    TIMEOUT,
 )
 from constans.scenarios import (
     BOARD_FOR_MOVE_AND_MODIFY_SCORE,
@@ -47,27 +47,25 @@ from constans.scenarios import (
     DICTIONARY_MAK_MOV,
     DICTIONARY_MAK_MOV_P2,
     FILTER_MOVE_BOARD_ENE,
-    FILTER_MOVE_BOARD_H,
-    FILTER_MOVE_MAKE_MOVE,
+    filter_move_board_h,
+    filter_move_make_move,
     FIN_FILTER_MOVE_BOARD_ENE,
-    FIN_FILTER_MOVE_BOARD_H,
-    FIN_FILTER_MOVE_MAKE_MOVE,
+    fin_filter_move_board_h,
+    fin_filter_move_make_move,
     FIND_GOLD_POS_1,
     FIND_GOLD_POS_2,
     FIND_GOLD_POS_3,
     FIND_GOLD_POS_4,
     INITIAL_BIG_FAIL_BOARD,
-
-    MAKE_MOVE_BOARD,
-    MAKE_MOVE_BOARD_P2,
-
+    make_move_board,
+    make_move_board_p2,
     PARSE_CELL_SCENARIO,
     PARSE_CELL_SCENARIO_STR_PLAYER_1,
     PARSE_CELL_SCENARIO_STR_PLAYER_2,
-
     RECURSIVE,
     RECURSIVE_SIDE,
     RECURSIVE_SIDE_CORNER,
+    SCENARIO_STR_PLAYER_1,
     TEST_BOARD_INIT_PLAYER_1,
     TEST_BOARD_INIT_PLAYER_2,
     TEST_PLAYERS_CHARACTER_0,
@@ -75,7 +73,6 @@ from constans.scenarios import (
     TEST_PLAYERS_CHARACTER_2,
     WAY_GOLD_TWO_PLAYERS,
     VALID_HOLE_SCENARIO,
-    SCENARIO_STR_PLAYER_1,
 )
 from game.utils import posibles_positions
 from exceptions.personal_exceptions import (moveToYourOwnCharPositionException,
@@ -400,7 +397,7 @@ class TestGame(unittest.TestCase):
         player_2 = Player(p2)
         character_1_of_player_1 = player_1.characters[0]
         game._board[from_row][from_col].character = character_1_of_player_1
-        game.current_player = player_1
+        game.current_player = player_2
         with self.assertRaises(notYourCharacterException):
             game.is_valid_move(from_row, from_col,
                                to_row, to_col, player_2)
@@ -508,16 +505,16 @@ class TestGame(unittest.TestCase):
         self.assertEqual(str(char), expected)
 
     @parameterized.expand([  # case for filter event
-        (DICTIONARY_H, FILTER_MOVE_BOARD_H,
-         FIN_FILTER_MOVE_BOARD_H, [
+        (DICTIONARY_H, filter_move_board_h(),
+         fin_filter_move_board_h(), [
             Gold(), Gold(), Gold(), Gold(), Gold(), Diamond()
             ], 5, 1),
         (DICTIONARY_ENE, FILTER_MOVE_BOARD_ENE,
          FIN_FILTER_MOVE_BOARD_ENE, [
             Gold(), Gold(), Gold(), Gold(), Gold(), Diamond()
             ], 5, 1),
-        (DICT_FILTER_MOVE_MK, FILTER_MOVE_MAKE_MOVE,
-         FIN_FILTER_MOVE_MAKE_MOVE, [], 0, 0)
+        (DICT_FILTER_MOVE_MK, filter_move_make_move(),
+         fin_filter_move_make_move(), [], 0, 0)
     ])
     def test_filter_move(self, dictionary, initial_board,
                          finalboard, treasure, count_gold, count_diam):
@@ -534,7 +531,7 @@ class TestGame(unittest.TestCase):
         self.assertIsNone(diam_char)
 
     @parameterized.expand([  # after verify all posibilities make move
-         (DICTIONARY_MAK_MOV, MAKE_MOVE_BOARD,
+         (DICTIONARY_MAK_MOV, make_move_board(),
           3, 0, 0, 0, True, False, 2, 0),
     ])
     def test_make_move_P1(self, dictionary, initial_board,
@@ -566,7 +563,7 @@ class TestGame(unittest.TestCase):
         self.assertEqual(player_character.player.arrows, new_arrows)
 
     @parameterized.expand([  # after verify all posibilities make move
-         (DICTIONARY_MAK_MOV_P2, MAKE_MOVE_BOARD_P2,
+         (DICTIONARY_MAK_MOV_P2, make_move_board_p2(),
           5, 0, 1, 0, False, True, 3, 0)
     ])
     def test_make_move_P2(self, dictionary, initial_board,

--- a/test/test_treasure.py
+++ b/test/test_treasure.py
@@ -24,3 +24,7 @@ class TestTreasure(unittest.TestCase):
     def test_diamond(self):
         gold = Diamond()
         self.assertEqual(gold.value, SCORES["DIAMOND"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Migrate these methods from game class to board class:

- `is_valid_move`
- `is_a_player_character`
- `move_to_own_character_position`
- ` filter_move`
- `make_move`
Every method returns the string “CORRECT MOVE” in case the action is valid, otherwise, personal exceptions are raised.

Migrate their tests to `test_board.py `

Refactor some test scenarios, because they have lists that were modified with other tests. In order to avoid failures, I created functions that return a test scenario. So, every test that used the lists, now calls the function that returns a scenario, so that, the scenarios remain the same, without modifications for the next tests.

_At the moment, the methods are duplicated in the game class, until we can remove them without breaking the game and integrate the board fully into the game class._ 



