### PR TITLE
[PATCH] [EDA-1514] - next turn method

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -74,6 +74,7 @@ class WumpusGame():
         )
         self.current_player = self.player_1
         self.game_is_active = True
+        self.remaining_moves = 200
 
     def move_to_own_character_position(self, player_game, row_to, col_to):
         ch = self._board[row_to][col_to].character
@@ -448,3 +449,7 @@ class WumpusGame():
         if self.current_player.invalid_moves_count >= MAXIMUM_INVALID_MOVES:
             self.current_player.penalizated_for_invalid_moves = True
             self.game_is_active = False
+
+    def next_turn(self):
+        self.remaining_moves -= 1
+        self.change_current_player()

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -835,6 +835,32 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.current_player.score, expected_score)
         self.assertEqual(game.game_is_active, game_active)
 
+    @parameterized.expand([
+        (PLAYER_1, 10, PLAYER_2, 9),
+        (PLAYER_1, 200, PLAYER_2, 199),
+        (PLAYER_2, 10, PLAYER_1, 9),
+        (PLAYER_2, 15, PLAYER_1, 14),
+    ])
+    def test_next_turn(self, initial_player, initial_remaining_moves,
+                       expected_player, expected_remainig_moves):
+
+        game = patched_game()
+
+        if PLAYER_1 == initial_player:
+            game.current_player = game.player_1
+        else:
+            game.current_player = game.player_2
+
+        game.remaining_moves = initial_remaining_moves
+
+        game.next_turn()
+
+        actual_player = game.current_player
+        actual_remaining_moves = game.remaining_moves
+
+        self.assertEqual(actual_player.name, expected_player)
+        self.assertEqual(actual_remaining_moves, expected_remainig_moves)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
create the `next_turn` method that only decreases the remaining moves in one and changes the current player