### PR TITLE
[PATCH EDA-1578]Fixed multiple diamonds bug

### DIFF
--- a/constans/scenarios.py
+++ b/constans/scenarios.py
@@ -31,6 +31,8 @@ player_1 = Player(PLAYER_1)
 character_player_1 = Character(player_1)
 BOARD_WIOUT_ITEMS[5][5].character = character_player_1
 
+EMPTY_BOARD = [[Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
+
 # scenarios to test recursive
 RECURSIVE = [[Cell(i, j) for j in range(LARGE)] for i in range(LARGE)]
 RECURSIVE[0][1].treasures.append(Gold())
@@ -541,6 +543,7 @@ SCENARIO_STR_PLAYER_1 = (
     "#####################################################################################"
     "  B  ################################################################################"
 )
+
 TEST_PLAYERS_CHARACTER_0 = Player(PLAYER_1)
 TEST_PLAYERS_CHARACTER_0.characters[0].treasures.extend([Gold()])
 TEST_PLAYERS_CHARACTER_0.characters[1].treasures.extend([Gold()])

--- a/game/board.py
+++ b/game/board.py
@@ -80,7 +80,7 @@ class Board():
                 self.place_items_in_free_position(start, end, item)
 
     def place_items_in_free_position(self, start: int, end: int, item):
-        while True:  # search until find an available position
+        while True:  # search until find an available positio
             row = random.randint(0, LARGE - 1)
             col = random.randint(start, end)
             if self._is_valid(row, col, item):

--- a/game/board.py
+++ b/game/board.py
@@ -58,6 +58,15 @@ class Board():
             self._board[row][col].is_discover[player_discover] = True
 
     def initial_diamond_position(self) -> None:
+        '''
+        #  DEBUG LINES for multiple diamnods bug,
+        #  left here in case further debugging is needed
+        print("initial_diamond called")
+        for row in range(LARGE):
+            for t in self._board[row][LARGE//2].treasures:
+                if isinstance(t, Diamond):
+                    print("Already one diamond in the map")
+        '''
         (
             self._board[random.randint(0, LARGE - 1)][LARGE//2]
             .treasures.append(Diamond())

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -30,6 +30,7 @@ from constans.scenarios import (
     DICTIONARY_H,
     DICTIONARY_MAK_MOV,
     DICTIONARY_MAK_MOV_P2,
+    EMPTY_BOARD,
     FILTER_MOVE_BOARD_ENE,
     filter_move_board_h,
     filter_move_make_move,
@@ -795,7 +796,8 @@ class TestBoard(unittest.TestCase):
         board.filter_move.assert_called_once_with(expected_result)
 
     def test_initial_diamond_position(self, row_random=4, expected_result=1):
-        board = patched_board()
+        board = Board()
+        board._board = EMPTY_BOARD
         mid_col = LARGE//2
         with patch('random.randint', return_value=row_random):
             board.initial_diamond_position()


### PR DESCRIPTION
Fixed bug. where the test function would occasionally fail. The bug was there because, in the test function test_initial_diamond_position(), the function initial_diamond_position() was called after the creation of a Board instance, and the Board() constructor already calls initial_diamond_position, thus creating 2 diamonds in the board.