### PR TITLE
[Patch][EDA-1577]place items bug fixed

### DIFF
--- a/constans/scenarios.py
+++ b/constans/scenarios.py
@@ -649,3 +649,13 @@ def generate_board_for_move_action_test():
     SCENARIOS_MOVE_TEST[5][4] = CELL_MOVE_5_4
 
     return SCENARIOS_MOVE_TEST, MOVED_PLAYER, OPPONENT_PLAYER
+
+
+DUPLICATE_FIRST_COOR_FOR_GOLDS_PLACEMENT = [
+    (2, 4), (2, 4), (4, 6), (5, 2), (7, 6), (9, 2), (11, 4), (11, 6), (12, 0),
+    (4, 10), (4, 12), (4, 15), (9, 10), (10, 16), (11, 12), (13, 12), (14, 10),
+]
+DUPLICATE_FIRST_COOR_FOR_HOLES_PLACEMENT = [
+    (3, 1), (3, 1), (3, 10), (3, 13), (4, 4), (6, 2), (6, 14), (8, 4), (9, 14),
+    (12, 11), (12, 14), (13, 2), (13, 4), (15, 2), (15, 12), (15, 14), (16, 4)
+]

--- a/game/cell.py
+++ b/game/cell.py
@@ -7,7 +7,7 @@ class Cell(TreasureHolder):
 
     def __init__(self, row, col):
         super().__init__()
-        self.position: tuple(row, col)
+        self.position = (row, col)
         self.character = None
         self.has_hole = False
         # self.is_discover_by_player_1 = False
@@ -72,3 +72,9 @@ class Cell(TreasureHolder):
         player = self.character.player
         player.characters.remove(self.character)
         self.character = None
+
+    def put_hole(self):
+        self.has_hole = True
+
+    def remove_hole(self):
+        self.has_hole = False


### PR DESCRIPTION
The _valid_hole() method in the Board class had a bug that can eventually block the creation of the boards.
This method placed a hole to verify if this position can block the path from each character to each gold. Nevertheless, in case the hole wasn't valid the method doesn't remove the hole. With the iterations the board could end with more than 16 holes or the method could enter in an infinity loop.

The method was fixed, so it removes the hole in case it is invalid.

Two tests were added:

-  One for control that only 16 can be placed 
- One to control that the case the hole previously placed to verify it is valid, was invalid, the hole must be removed

The property hole_numbers() was added to the Board class, 