### PR TITLE
[PATCH] [EDA-1601] Improve performance find_golds_method

### DIFF
--- a/game/board.py
+++ b/game/board.py
@@ -189,6 +189,7 @@ class Board():
         if (row, col) == gold_position:
             return True
         possible_moves = posibles_positions(row, col)
+        possible_moves = self.sort_possibles_position(possible_moves, *gold_position)
         for row_next, col_next in possible_moves:
             if (
                 (row_next, col_next) not in visited and
@@ -198,6 +199,14 @@ class Board():
             ):
                 return True
         return False
+
+    def sort_possibles_position(self, positions, destination_row, destination_col) -> list:
+        def sorted_key(position) -> int:
+            row, col = position
+            # Euclidean distance between two points √((d_row - row)²+(d_col -col)²)
+            # The 0.1 it's to give advantage to pick col direction over row direction going from left to right
+            return ((destination_row - (row + 0.1)) ** 2 + (destination_col - col) ** 2) ** (0.5)
+        return sorted(positions, key=sorted_key)
 
     def shoot_arrow(
         self,

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -865,6 +865,26 @@ class TestBoard(unittest.TestCase):
         self.assertEqual(board._free_cells_left_half, LEFT_HALF_COORDS)
         self.assertEqual(board._free_cells_right_half, RIGHT_HALF_COORDS)
 
+    @parameterized.expand([
+        ('from (0, 0) to (3, 3)', 3, 3, [(1, 0), (0, 1), ], [(0, 1), (1, 0), ]),
+        ('from (0, 1) to (3, 3)', 3, 3, [(0, 0), (0, 2), (1, 1), ], [(1, 1), (0, 2), (0, 0)]),
+        ('from (1, 1) to (3, 3)', 3, 3, [(0, 1), (2, 1), (1, 0), (1, 2)], [(1, 2), (2, 1), (0, 1), (1, 0), ]),
+        ('from (1, 2) to (3, 3)', 3, 3, [(0, 2), (2, 2), (1, 3), (1, 1)], [(2, 2), (1, 3), (1, 1), (0, 2), ]),
+        ('from (2, 2) to (3, 3)', 3, 3, [(1, 2), (3, 2), (2, 3), (2, 1)], [(2, 3), (3, 2), (1, 2), (2, 1), ]),
+        ('from (2, 3) to (3, 3)', 3, 3, [(1, 3), (3, 3), (2, 4), (2, 2)], [(3, 3), (2, 4), (2, 2), (1, 3), ]),
+
+        ('from (0, 0) to (2, 0)', 2, 0, [(1, 0), (0, 1), ], [(1, 0), (0, 1), ]),
+        ('from (1, 0) to (2, 0)', 2, 0, [(0, 0), (1, 1), (2, 0)], [(2, 0), (1, 1), (0, 0), ]),
+
+    ])
+    def test_sort_possibles_position(self, name,
+                                     destination_row, destination_col,
+                                     positions, expeted_sorted_possitions):
+        board = patched_board()
+        sorted_possitions = board.sort_possibles_position(positions,
+                                                          destination_row, destination_col,)
+        self.assertEqual(sorted_possitions, expeted_sorted_possitions)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `_can_find_gold` is a method that makes a search using recursive to try to find a way to go to the golds from a character.

This has the purpose to know if putting a hole is valid or not, by checking if all the characters can access the golds in the board.
But the problem with this was that it was doing a dummy search.
I add a method `sort_possibles_position` that adds a little intelligence to the search, going always first to the cell that make the character close to the gold.

OLD `_can_find_gold`
<img src="https://user-images.githubusercontent.com/113444840/191598989-6e3d094a-aa0e-482d-b570-764b9d6bfc74.jpg" width="400">


NEW `_can_find_gold`
<img src="https://user-images.githubusercontent.com/113444840/191599111-dec0109a-b020-4e1f-9011-b16c5dd490ec.jpeg" width="400">

