### PR TITLE
[EDA-1592] - grpc interface in wumpus-game

### DIFF
--- a/game/grpc_interface.py
+++ b/game/grpc_interface.py
@@ -1,0 +1,25 @@
+from edagames_grpc.server import ServerInterface
+from edagames_grpc.game_state import GameState
+from edagames_grpc.game_start import GameStart
+
+from game.manager import Manager
+
+from typing import List, Dict
+
+
+MANAGER = Manager()
+
+
+class Interface(ServerInterface):
+
+    async def create_game(self, players: List[str]) -> GameStart:
+        return MANAGER.create_game(players)
+
+    async def penalize(self, game_id: str) -> GameState:
+        return MANAGER.penalize(game_id)
+
+    async def end_game(self, game_id: str) -> GameState:
+        return MANAGER.abort(game_id)
+
+    async def execute_action(self, game_id: str, game_data: Dict) -> GameState:
+        return MANAGER.process_request(game_id, game_data)

--- a/test/test_grpc_interface.py
+++ b/test/test_grpc_interface.py
@@ -1,0 +1,36 @@
+from game.grpc_interface import Interface
+from unittest import IsolatedAsyncioTestCase
+from game.manager import Manager
+from unittest.mock import patch
+
+
+class TestInterface(IsolatedAsyncioTestCase):
+
+    @patch.object(Manager, 'create_game')
+    async def test_create_game(self, mock_method):
+        interface = Interface()
+        names = ['name1', 'name2']
+        await interface.create_game(names)
+        mock_method.assert_called_once_with(names)
+
+    @patch.object(Manager, 'penalize')
+    async def test_penalize(self, mock_method):
+        interface = Interface()
+        id_game = 'game_id'
+        await interface.penalize(id_game)
+        mock_method.assert_called_once_with(id_game)
+
+    @patch.object(Manager, 'abort')
+    async def test_end_game(self, mock_method):
+        interface = Interface()
+        id_game = 'game_id'
+        await interface.end_game(id_game)
+        mock_method.assert_called_once_with(id_game)
+
+    @patch.object(Manager, 'process_request')
+    async def test_process_request(self, mock_method):
+        interface = Interface()
+        id_game = 'one_id'
+        dictio = {'key1': 'value1'}
+        await interface.execute_action(id_game, dictio)
+        mock_method.assert_called_once_with(id_game, dictio)


### PR DESCRIPTION
In this PR, the grpc interface was implemented and tested, it was the final step in the wumpus game to the server, it needed previously have a manager created

in grpc_interface we have 4 async methods: create_game, penalize, end_game, execute_action declared in the server and in the client side, call functions: create_game, penalize, abort and process_request respectively.