### PR TITLE
[MINOR][EDA-1641] change create game and penalize function

### DIFF
--- a/game/manager.py
+++ b/game/manager.py
@@ -110,6 +110,7 @@ class Manager():
     def create_game(self, users_names: List[str]) -> GameStart:
         if len(users_names) in [2, 4]:
             new_game = WumpusGame(users_names)
+            self.add_game(new_game)
             return self.get_game_start(new_game)
         else:
             raise InvalidQuantityPlayers()
@@ -154,3 +155,6 @@ class Manager():
             current_game,
             state,
         )
+
+    def add_game(self, game: WumpusGame) -> None:
+        self.games[game.game_id] = game

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -275,25 +275,25 @@ class TestManager(unittest.TestCase):
     def test_penalize_with_game_over(self, mok_game_set):
         manag = Manager()
         users_names = [NAME_USER_1, NAME_USER_2]
-        game = WumpusGame(users_names)
-        game_id = "123asd"
-        game.game_id = game_id
-        game.game_is_active = False
-        manag.games[game_id] = game
-        manag.penalize(game_id)
-        mok_game_set.assert_called_once_with(game, GAMEOVER_STATE)
+        manag.create_game(users_names)
+        key_manag = ""
+        for key in manag.games:
+            key_manag = key
+        with patch('game.manager.Manager.check_game_over', return_value=True):
+            manag.penalize(key_manag)
+            mok_game_set.assert_called_once_with(manag.games[key_manag], GAMEOVER_STATE)
 
     @patch('game.manager.Manager.get_game_state')
     def test_penalize_without_game_over(self, mok_game_set):
         manag = Manager()
         users_names = [NAME_USER_1, NAME_USER_2]
-        game = WumpusGame(users_names)
-        game_id = "123asd"
-        game.game_id = game_id
-        manag.games[game_id] = game
-        manag.penalize(game_id)
+        manag.create_game(users_names)
+        key_manag = ""
+        for key in manag.games:
+            key_manag = key
+        manag.penalize(key_manag)
         self.assertEqual(manag.action_data, INVALID_PENALIZE)
-        mok_game_set.assert_called_once_with(game, TIMEOUT)
+        mok_game_set.assert_called_once_with(manag.games[key_manag], TIMEOUT)
 
     @patch.object(Manager, 'find_game')
     @patch.object(Manager, 'get_game_state')


### PR DESCRIPTION
When the server calls the manager and creates a Wumpus Game need save a create game in WumpusGame instances. Also, we create an add_game function and add in create_game. Modified penalize game test to use manager create_game function 