### PR TITLE
PATCH [EDA - 1631] Modified responses as discussed with teammates

### DIFF
--- a/constans/constants_messages.py
+++ b/constans/constants_messages.py
@@ -2,28 +2,28 @@ from constans.scenarios import SCENARIO_STR_PLAYER_1
 from constans.constans import (
     INITIAL_ARROWS,
     NAME_USER_1,
-    NAME_USER_2
+    NAME_USER_2,
 )
 
 GAME_OVER_MESSAGE_1 = "GAME OVER - Player 1 reached 5 invalid moves in a row"
 GAME_OVER_MESSAGE_2 = "GAME OVER - Player 2 reached 5 invalid moves in a row"
-GAME_OVER_MESSAGE_3 = "GAME OVER - No turns left"
+GAME_OVER_MESSAGE_3 = "GAME OVER - DRAW. No turns left and scores are the same."
 GAME_OVER_MESSAGE_4 = "GAME OVER - Player 1 has no living Characters..."
 GAME_OVER_MESSAGE_5 = "GAME OVER - Player 2 has no living Characters..."
+GAME_OVER_MESSAGE_6 = "GAME OVER - No turns left - Player 1 wins by score difference"
+GAME_OVER_MESSAGE_7 = "GAME OVER - No turns left - Player 2 wins by score difference"
 GAME_OVER_NOT_MET = "Game comtinues..."
 
 RESPONSE_1 = {
-    "event": "GAME_OVER",
-    "data": {
-        "status": GAME_OVER_MESSAGE_4,
-        'SCORE': {
-            'B': -100,
-            'P': 0,
-        },
-        'RESULT': {
-            'WINNER': 'P',
-            'LOSER': 'B',
-        }
+    "status": GAME_OVER_MESSAGE_4,
+    "winner_side": "P",
+    'score': {
+        'player_1': -100,
+        'player_2': 0,
+    },
+    'result': {
+        'WINNER': NAME_USER_2,
+        'LOSER': NAME_USER_1,
     }
 }
 
@@ -42,16 +42,50 @@ RESPONSE_2 = {
 }
 
 RESPONSE_3 = {
-    "event": "GAME_OVER",
-    "data": {
-        "status": GAME_OVER_MESSAGE_5,
-        'SCORE': {
-            'B': 0,
-            'P': -100,
-        },
-        'RESULT': {
-            'WINNER': 'B',
-            'LOSER': 'P',
-        }
+    "status": GAME_OVER_MESSAGE_5,
+    "winner_side": "B",
+    'score': {
+        'player_1': 0,
+        'player_2': -100,
+    },
+    'result': {
+        'WINNER': NAME_USER_1,
+        'LOSER': NAME_USER_2,
+    }
+}
+
+RESPONSE_4 = {
+    "status": GAME_OVER_MESSAGE_3,
+    "winner_side": "DRAW",
+    'score': {
+        'player_1': 0,
+        'player_2': 0,
+    },
+    'result': "DRAW",
+}
+
+RESPONSE_6 = {
+    "status": GAME_OVER_MESSAGE_6,
+    "winner_side": "B",
+    'score': {
+        'player_1': 5000,
+        'player_2': 1000,
+    },
+    'result': {
+        'WINNER': NAME_USER_1,
+        'LOSER': NAME_USER_2,
+    }
+}
+
+RESPONSE_7 = {
+    "status": GAME_OVER_MESSAGE_7,
+    "winner_side": "P",
+    'score': {
+        'player_1': 1000,
+        'player_2': 5000,
+    },
+    'result': {
+        'WINNER': NAME_USER_2,
+        'LOSER': NAME_USER_1,
     }
 }

--- a/game/game.py
+++ b/game/game.py
@@ -1,5 +1,4 @@
 from constans.constans import (
-    DATA,
     JOIN_ROW_BOARD,
     MAXIMUM_INVALID_MOVES,
     MOVE,
@@ -30,6 +29,8 @@ from constans.constants_messages import (
     GAME_OVER_MESSAGE_3,
     GAME_OVER_MESSAGE_4,
     GAME_OVER_MESSAGE_5,
+    GAME_OVER_MESSAGE_6,
+    GAME_OVER_MESSAGE_7,
     GAME_OVER_NOT_MET,
 )
 
@@ -189,26 +190,35 @@ class WumpusGame():
         else:
             final_message = self.game_over_final_message()['GAME_OVER']
             response = {
-                "event": "GAME_OVER",
-                DATA: {
-                    "status": game_over_data[1],
-                    'SCORE': final_message['SCORE'],
-                    'RESULT': final_message['RESULT'],
-                },
+                "status": game_over_data[1],
+                "winner_side": self.get_winner_side(game_over_data[1]),
+                "score": final_message['SCORE'],
+                "result": final_message['RESULT'],
             }
             return response
 
+    def get_winner_side(self, game_over_message):
+        winner_dictionary = {
+            GAME_OVER_MESSAGE_1: self.player_2.name,
+            GAME_OVER_MESSAGE_2: self.player_1.name,
+            GAME_OVER_MESSAGE_3: "DRAW",
+            GAME_OVER_MESSAGE_4: self.player_2.name,
+            GAME_OVER_MESSAGE_5: self.player_1.name,
+            GAME_OVER_MESSAGE_6: self.player_1.name,
+            GAME_OVER_MESSAGE_7: self.player_2.name,
+        }
+        return winner_dictionary[game_over_message]
+
     def game_over_final_message(self):
-        #  Will need debug since outcome is determined only by player´s score
-        name_player_1, name_player_2 = self.player_1.name, self.player_2.name
+        name_player_1, name_player_2 = self.player_1.user_name, self.player_2.user_name
         score_player_1 = self.player_1.score
         score_player_2 = self.player_2.score
-        if score_player_1 == score_player_2:
+        if score_player_1 == score_player_2 and self.player_1.score == self.player_2.score:
             return {
                 'GAME_OVER': {
                     'SCORE': {
-                        name_player_1: score_player_1,
-                        name_player_2: score_player_2,
+                        "player_1": score_player_1,
+                        "player_2": score_player_2,
                     },
                     'RESULT': 'DRAW',
                 },
@@ -216,8 +226,8 @@ class WumpusGame():
         return {
             'GAME_OVER': {
                 'SCORE': {
-                    name_player_1: score_player_1,
-                    name_player_2: score_player_2,
+                    "player_1": score_player_1,
+                    "player_2": score_player_2,
                 },
                 'RESULT': {
                     'WINNER': (name_player_1 if score_player_1 > score_player_2
@@ -241,9 +251,14 @@ class WumpusGame():
         game_over_conditions = {
             GAME_OVER_MESSAGE_4: len(self.player_1.characters) == 0,
             GAME_OVER_MESSAGE_5: len(self.player_2.characters) == 0,
-            GAME_OVER_MESSAGE_3: (self.remaining_moves == 0),
+            GAME_OVER_MESSAGE_3: (self.remaining_moves == 0 and
+                                  self.player_1.score == self.player_2.score),
             GAME_OVER_MESSAGE_1: (self.player_1.invalid_moves_count) >= 5,
             GAME_OVER_MESSAGE_2: (self.player_2.invalid_moves_count) >= 5,
+            GAME_OVER_MESSAGE_6: (self.remaining_moves == 0 and
+                                  self.player_1.score > self.player_2.score),
+            GAME_OVER_MESSAGE_7: (self.remaining_moves == 0 and
+                                  self.player_1.score < self.player_2.score),
         }
         return game_over_conditions
 

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -50,6 +50,9 @@ from constans.constants_messages import (
     RESPONSE_1,
     RESPONSE_2,
     RESPONSE_3,
+    RESPONSE_4,
+    RESPONSE_6,
+    RESPONSE_7,
 )
 from constans.scenarios import (
     BOARD_FOR_MOVE_AND_MODIFY_SCORE,
@@ -237,35 +240,35 @@ class TestGame(unittest.TestCase):
         (10000, 8000, {
             'GAME_OVER': {
                 'SCORE': {
-                    PLAYER_1: 10000,
-                    PLAYER_2: 8000,
+                    "player_1": 10000,
+                    "player_2": 8000,
                 },
                 'RESULT': {
-                    'WINNER': PLAYER_1,
-                    'LOSER': PLAYER_2,
+                    'WINNER': NAME_USER_1,
+                    'LOSER': NAME_USER_2,
                 }
             }
         }),
         (8000, 10000, {
             'GAME_OVER': {
                 'SCORE': {
-                    PLAYER_1: 8000,
-                    PLAYER_2: 10000,
+                    "player_1": 8000,
+                    "player_2": 10000,
                 },
                 'RESULT': {
-                    'WINNER': PLAYER_2,
-                    'LOSER': PLAYER_1,
+                    'WINNER': NAME_USER_2,
+                    'LOSER': NAME_USER_1,
                 }
             }
         }),
         (10000, 10000, {
             'GAME_OVER': {
                 'SCORE': {
-                    PLAYER_1: 10000,
-                    PLAYER_2: 10000,
+                    "player_1": 10000,
+                    "player_2": 10000,
                 },
                 'RESULT': 'DRAW',
-            },
+            }
         }),
     ])
     def test_game_over_final_message(
@@ -304,21 +307,25 @@ class TestGame(unittest.TestCase):
         self.assertIsInstance(game._board, Board)
 
     @parameterized.expand([  # test generate response
-        ("p1", RESPONSE_1),
-        (None, RESPONSE_2),
-        ("p2", RESPONSE_3)
+        ("p1", -100, 0, 50, RESPONSE_1),
+        (None, 0, 0, 200, RESPONSE_2),
+        ("p2", 0, -100, 30,  RESPONSE_3),
+        (None, 0, 0, 0, RESPONSE_4),
+        (None, 5000, 1000, 0, RESPONSE_6),
+        (None, 1000, 5000, 0, RESPONSE_7),
     ])
-    def test_generate_response(self, noChars, response):
+    def test_generate_response(self, noChars, p1_score, p2_score, rem, response):
         game = WumpusGame([NAME_USER_1, NAME_USER_2])
         self.maxDiff = None
         game_id = "1234-5678-9012-3456-7890"
         game.game_id = game_id
+        game.player_1.score = p1_score
+        game.player_2.score = p2_score
+        game.remaining_moves = rem
         if (noChars == "p1"):
             game.player_1.characters = []
-            game.player_1.score = -100
         elif (noChars == "p2"):
             game.player_2.characters = []
-            game.player_2.score = -100
         self.assertEqual(game.generate_response(), response)
 
     @parameterized.expand([


### PR DESCRIPTION
Modified response generated at edagames-wumpus/games.py. Modified methods generates_response() and game_over_final_message(). The generic turn response is basically the same, but the GAME OVER message changes significantly.  Now, it has the following format:

Example_1 = {
    "status": "GAME OVER - Player 2 has no living Characters...",
    "winner_side": "B",
    'score': {
        'player_1': 0,
        'player_2': -100,
    },
    'result': {
        'WINNER': "name_of_p_1",
        'LOSER': "other_name",
    }
}

EXAMPLE_2 = {  ##. Note that a "DRAW" is an extremely rare case.
    "status": "GAME OVER - No more turns remaining...",
    "winner_side": "B",
    'score': {
        'player_1': 0,
        'player_2': 0,
    },
    'result': "DRAW",
}

Also, most important, the message sent to users was modified so it considers that the game will not be a DRAW if there are no more turns left but the scores are not te same. Examples:

Example_3 = {
    "status": "GAME_OVER - No more turns left. Player 1 wins by score difference.",
    "winner_side": "B",
    'score': {
        'player_1': 5000,
        'player_2': 1000,
    },
    'result': {
        'WINNER': NAME_USER_1,
        'LOSER': NAME_USER_2,
    }
}

Example_4 = {
    "status": "GAME_OVER - No more turns left. Player 2 wins by score difference.",
    "winner_side": "P"
    'score': {
        'player_1': 1000,
        'player_2': 5000,
    },
    'result': {
        'WINNER': NAME_USER_2,
        'LOSER': NAME_USER_1,
    }
}
