### PR TITLE
[PATCH][EDA-1656] fix bug of the process request

### DIFF
--- a/game/manager.py
+++ b/game/manager.py
@@ -62,6 +62,7 @@ class Manager():
                 api_data[DATA],
                 MESSAGE_DATA_KEYS
             )
+            api_data[DATA].update(self.action_data)
             game.execute_action(
                 api_data[ACTION],
                 api_data[DATA][ROW],

--- a/game/manager.py
+++ b/game/manager.py
@@ -39,16 +39,21 @@ class Manager():
             message = {}
             for key in data_keys:
                 value = data[key]
-                if value in POSIBLE_DIRECTIONS:
-                    message[key] = value
-                elif key != DIRECTION_MESSAGE and type(value) != bool:
-                    message[key] = int(value)
-                else:
-                    raise InvalidData()
+                message[key] = self.get_correct_value(key, value)
             return message
         except KeyError:
             raise InvalidKey()
         except ValueError:
+            raise InvalidData()
+
+    def get_correct_value(self, key, value):
+        if key == DIRECTION_MESSAGE and value in POSIBLE_DIRECTIONS:
+            return value
+        elif type(value) == bool:
+            raise InvalidData()
+        elif key == ROW or key == COL:
+            return int(value)
+        else:
             raise InvalidData()
 
     def execute_action_manager(self, game: WumpusGame, api_data: dict()):
@@ -136,9 +141,10 @@ class Manager():
             raise InvalidData()
 
     def process_request(self, game_id: str, api_data: dict) -> GameState:
-        current_game = self.find_game(game_id)
+
         state = INVALID_STATE
         try:
+            current_game = self.find_game(game_id)
             self.execute_action_manager(current_game, api_data)
         except InvalidData:
             current_game.penalize_player()

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -416,3 +416,45 @@ class TestManager(unittest.TestCase):
         }
         result = manager.get_correct_data(data_message, MESSAGE_DATA_KEYS)
         self.assertEqual(result, expected_result)
+
+    @parameterized.expand([
+        (0.0, 4.0),
+        ('0', '4'),
+    ])
+    @patch('game.game.WumpusGame.execute_action')
+    def test_execute_action_is_coverting_index(self, from_row, from_col, mock_execute_action):
+        manager = Manager()
+        game = patched_game()
+        api_data = dict(
+            {
+                ACTION: MOVE,
+                DATA: {
+                    ROW: from_row,
+                    COL: from_col,
+                    DIRECTION_MESSAGE: NORTH
+                }
+            }
+        )
+        manager.execute_action_manager(game, api_data)
+        mock_execute_action.assert_called_once_with(
+            MOVE,
+            0,
+            4,
+            NORTH
+        )
+
+    def test_execute_action_raise_an_error_of_convertion(self):
+        manager = Manager()
+        game = patched_game()
+        api_data = dict(
+            {
+                ACTION: MOVE,
+                DATA: {
+                    ROW: 'a',
+                    COL: 'b',
+                    DIRECTION_MESSAGE: NORTH
+                }
+            }
+        )
+        with self.assertRaises(InvalidData):
+            manager.execute_action_manager(game, api_data)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -397,3 +397,22 @@ class TestManager(unittest.TestCase):
             with patch('game.manager.Manager.check_game_over', return_value=True):
                 manag.process_request(game_id, manag.action_data)
                 get_game_mock.assert_called_once_with(game, GAMEOVER_STATE)
+
+    @parameterized.expand([
+        (1.0, 2.0, 1, 2),
+        ('1', 1, 1, 1),
+    ])
+    def test_convertion_index_when_are_no_tints(self, from_row, from_col, expeted_row, expected_col):
+        manager = Manager()
+        data_message = {
+            'from_row': from_row,
+            'from_col': from_col,
+            'direction': WEST
+        }
+        expected_result = {
+            'from_row': expeted_row,
+            'from_col': expected_col,
+            'direction': WEST
+        }
+        result = manager.get_correct_data(data_message, MESSAGE_DATA_KEYS)
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
When our bot was sending a message of action the WebSocket connection with the server was been closed. I debug and check all the bots, and the message seemed to be valid, so the problem was on the server side

The error logged said something about trying to index a list with a `float` (`from_col` an `from_row`), which was confusing because the `request_data` received in the server was alright. and both `from_col` an `from_row` were `int`

Between the `FastAPI SERVER` and the `wumpus app` the connection is doing through `gRPC`, for some reason I can't explain, gRPC was changing the type of `from_col` and `from_row` index

I only made a refactor of the `Manager.get_correct_data( )` to take count of this bug not contemplated
I had to separate part of the method in other one `Manager.get_correct_value( )` because of the code climate complexity