### PR TITLE
[MINOR][EDA-1652][EDA-1663] - Move class and Move and Die

### DIFF
--- a/application/move.py
+++ b/application/move.py
@@ -30,11 +30,14 @@ class Move(Action):
         if coordinates is False:
             raise noPossibleMoveException()
 
-        to_row, to_col = coordinates
-        if is_frendly_fire(to_row, to_col, current_player, board):
+        # to_row, to_col = coordinates
+        # reutilize the friendly fire method for moving to a same player character
+        if is_frendly_fire(from_row, from_col, direction, current_player, board):
             raise moveToYourOwnCharPositionException()
 
         else:
+            # continue the chain of responsability
             if self.get_next_action():
                 return self.get_next_action().execute(from_row, from_col, direction, current_player, board)
+
             raise invalidMoveException("Invalid move")

--- a/application/move.py
+++ b/application/move.py
@@ -1,0 +1,40 @@
+from application.action import Action
+
+from application.utils import (
+    is_a_player_character,
+    target_position_within_bounds,
+    is_frendly_fire,
+)
+
+from exceptions.personal_exceptions import (
+    notYourCharacterException,
+    noPossibleMoveException,
+    moveToYourOwnCharPositionException,
+    invalidMoveException,
+
+)
+from game.board import Board
+from game.player import Player
+
+
+class Move(Action):
+
+    def execute(self, from_row: int, from_col: int, direction: str, current_player: Player, board: Board):
+
+        # check if the character is a current_player character
+        if not is_a_player_character(from_row, from_col, current_player, board):
+            raise notYourCharacterException()
+
+        # check if the direction is out of bounds (out of board)
+        coordinates = target_position_within_bounds(from_row, from_col, direction)
+        if coordinates is False:
+            raise noPossibleMoveException()
+
+        to_row, to_col = coordinates
+        if is_frendly_fire(to_row, to_col, current_player, board):
+            raise moveToYourOwnCharPositionException()
+
+        else:
+            if self.get_next_action():
+                return self.get_next_action().execute(from_row, from_col, direction, current_player, board)
+            raise invalidMoveException("Invalid move")

--- a/application/move_and_die.py
+++ b/application/move_and_die.py
@@ -1,0 +1,32 @@
+from constans.constants_scores import CORRECT_MOVE
+from application.action import Action
+from application.utils import target_position_within_bounds
+from exceptions.personal_exceptions import invalidMoveException
+from game.board import Board
+from game.cell import Cell
+from game.character import Character
+from game.player import Player
+
+
+class MoveAndDie(Action):
+
+    def execute(self, from_row, from_col, direction, current_player: Player, board: Board):
+        to_row, to_col = target_position_within_bounds(from_row, from_col, direction)
+        origin_cell: Cell = board.get_cell(from_row, from_col)
+        target_cell: Cell = board.get_cell(to_row, to_col)
+        character_target_cell: Character = target_cell.character
+        character_origin_cell: Character = origin_cell.character
+
+        # check if there is an opponent character
+        if character_target_cell.player is not None and character_target_cell.player is not current_player:
+            character_origin_cell.transfer_tresaure(origin_cell)
+            origin_cell.remove_character()
+            board.discover_cell(to_row, to_col, current_player)
+            return CORRECT_MOVE
+
+        # continue the chain of responsability
+        else:
+            if self.get_next_action():
+                return self.get_next_action().execute(from_row, from_col, direction, current_player, board)
+
+            raise invalidMoveException("Invalid move")

--- a/application/utils.py
+++ b/application/utils.py
@@ -9,7 +9,7 @@ def is_a_player_character(row, col, current_player: Player, board: Board) -> boo
     cell = board.get_cell(row, col)
     character: Character = cell.character
     if character:
-        return character.player.user_name == current_player.user_name
+        return character.player.name == current_player.name
     return False
 
 

--- a/test/test_application_move.py
+++ b/test/test_application_move.py
@@ -1,8 +1,75 @@
-import unittest
-from parameterized import parameterized
-from application.action import Action
 from application.move import Move
+from application.move_and_die import MoveAndDie
+from constans.constans import NORTH, SOUTH, WEST
+from constans.scenarios import (
+    generate_board_for_move_action_test,
+)
+
+from exceptions.personal_exceptions import (
+    invalidMoveException,
+    moveToYourOwnCharPositionException,
+    notYourCharacterException,
+    noPossibleMoveException,
+)
+
+from game.board import Board
+from parameterized import parameterized
+import unittest
+from unittest.mock import MagicMock, patch
 
 
 class TestMove(unittest.TestCase):
-    pass
+
+    def setUp(self):
+        self.scenarios, self.moving_player, self.opponent_player = generate_board_for_move_action_test()
+        self.move = Move()
+        self.board = Board()
+
+    @parameterized.expand([
+        ('raise_invalid_move_exception', 4, 4, WEST, invalidMoveException),
+        ('raise_move_to_your_own_char_exception', 4, 4, SOUTH, moveToYourOwnCharPositionException),
+        ('raise_no_possible_move_exception', 0, 0, NORTH, noPossibleMoveException),
+        ('raise_not_your_character_exeption_1', 9, 8, SOUTH, notYourCharacterException),
+        ('raise_not_your_character_exeption_2', 3, 4, SOUTH, notYourCharacterException),
+    ])
+    def test_analize_the_correct_rising_exception_for_each_case_in_move(
+        self,
+        name_of_the_testcase,
+        row,
+        col,
+        direction,
+        exception_expected_to_raise,
+    ):
+        self.board._board = self.scenarios
+        with self.assertRaises(exception_expected_to_raise):
+            self.move.execute(
+                row,
+                col,
+                direction,
+                self.moving_player,
+                self.board
+                )
+
+    @parameterized.expand([
+        ('NEXT_ACTION', 'execute', 4, 4, WEST)
+    ])
+    def test_execute_valid_move_continue__the_chain_of_responsability(
+        self,
+        name_of_the_test_case,
+        execute_pathced,
+        row,
+        col,
+        direction,
+
+    ):
+        self.move.get_next_action = MagicMock(return_value=MoveAndDie)
+        self.board._board = self.scenarios
+        with patch.object(Move, execute_pathced, return_value='_') as patched_method_execute:
+            self.move.execute(
+                row,
+                col,
+                direction,
+                self.moving_player,
+                self.board
+                )
+        patched_method_execute.assert_called_once()

--- a/test/test_application_move.py
+++ b/test/test_application_move.py
@@ -1,0 +1,8 @@
+import unittest
+from parameterized import parameterized
+from application.action import Action
+from application.move import Move
+
+
+class TestMove(unittest.TestCase):
+    pass

--- a/test/test_application_move_and_die.py
+++ b/test/test_application_move_and_die.py
@@ -26,7 +26,6 @@ class TestMoveAndDie(unittest.TestCase):
         result = self.move_n_die.execute(row, col, direction, self.moving_player, self.board)
         self.assertEqual(result, expected_result)
         self.assertEqual(self.board._board[row][col].character, None)
-        # self.assertEqual(self.board._board[to_row][to_col].character.player.name, self.moving_player.name)
 
     @parameterized.expand([
         (4, 4, NORTH, 0, 0, [Gold()], 1, 0),

--- a/test/test_application_move_and_die.py
+++ b/test/test_application_move_and_die.py
@@ -1,0 +1,113 @@
+import unittest
+from parameterized import parameterized
+from constans.constans import SOUTH, NORTH
+from constans.constants_scores import CORRECT_MOVE
+from game.board import Board
+from game.cell import Cell
+from constans.scenarios import generate_board_for_move_action_test
+from application.move_and_die import MoveAndDie
+from game.gold import Gold
+from game.diamond import Diamond
+from exceptions.personal_exceptions import invalidMoveException
+
+
+class TestMoveAndDie(unittest.TestCase):
+
+    def setUp(self):
+        self.scenarios, self.moving_player, self.opponent_player = generate_board_for_move_action_test()
+        self.move_n_die = MoveAndDie()
+        self.board = Board()
+
+    @parameterized.expand([
+        (4, 4, NORTH, CORRECT_MOVE),
+    ])
+    def test_execute_move_and_die_return_correct_move(self, row, col, direction, expected_result):
+        self.board._board = self.scenarios
+        result = self.move_n_die.execute(row, col, direction, self.moving_player, self.board)
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.board._board[row][col].character, None)
+        # self.assertEqual(self.board._board[to_row][to_col].character.player.name, self.moving_player.name)
+
+    @parameterized.expand([
+        (4, 4, NORTH, 0, 0, [Gold()], 1, 0),
+        (4, 4, NORTH, 0, 0, [Diamond()], 0, 1),
+        (4, 4, NORTH, 0, 0, [Gold(), Diamond(), Gold(), Diamond()], 2, 2),
+    ])
+    def test_execute_move_and_die_transfer_treasure(
+        self,
+        row,
+        col,
+        direction,
+        expected_init_gold,
+        expected_init_diamond,
+        treasure_to_add_to_the_character,
+        expected_final_gold,
+        expected_final_diamond,
+    ):
+        self.board._board = self.scenarios
+        cell: Cell = self.board.get_cell(row, col)
+
+        # before the character dies treasures in cell
+        self.assertEqual(cell.gold, expected_init_gold)
+        self.assertEqual(cell.diamond, expected_init_diamond)
+
+        cell.character.treasures.extend(treasure_to_add_to_the_character)
+        self.move_n_die.execute(row, col, direction, self.moving_player, self.board)
+
+        # after the character dies treasures in cell
+        self.assertEqual(cell.gold, expected_final_gold)
+        self.assertEqual(cell.diamond, expected_final_diamond)
+
+    @parameterized.expand([
+        (4, 4, NORTH, None),
+        (8, 8, SOUTH, None),
+    ])
+    def test_execute_move_die_and_remove_the_character(
+        self,
+        row,
+        col,
+        direction,
+        expected_character_in_origin_cell
+    ):
+        self.board._board = self.scenarios
+        cell: Cell = self.board.get_cell(row, col)
+        self.move_n_die.execute(row, col, direction, self.moving_player, self.board)
+        self.assertEqual(cell.character, expected_character_in_origin_cell)
+
+    @parameterized.expand([
+        (4, 4, NORTH, 3, 4, True),
+        (8, 8, SOUTH, 9, 8, True),
+    ])
+    def test_execute_move_die_and_discover_the_cell(
+        self,
+        row,
+        col,
+        direction,
+        to_row,
+        to_col,
+        discover_final_status,
+    ):
+        self.board._board = self.scenarios
+        cell: Cell = self.board.get_cell(to_row, to_col)
+        self.move_n_die.execute(row, col, direction, self.moving_player, self.board)
+        self.assertEqual(cell.is_discover[0], discover_final_status)
+
+    @parameterized.expand([
+        (4, 4, SOUTH, invalidMoveException)
+    ])
+    def test_execute_invalid_move_and_die_raise_exception(
+        self,
+        row,
+        col,
+        direction,
+        exception_raised,
+    ):
+        self.board._board = self.scenarios
+        with self.assertRaises(exception_raised):
+            self.move_n_die.execute(
+                row,
+                col,
+                direction,
+                self.moving_player,
+                self.board
+                )


### PR DESCRIPTION
We are seeing that the board class manages the logic of the Movement and verification when it should not do that.
The team decide to move Move and Shoot to an application layer(a folder), where move now has a chain of responsibility, if one of the links breaks in his responsibility returns an error, 
the chain of responsibility structure of move is: Move -> MoveAndDie -> MoveToHole -> MoveToEmpty
this chain also makes more simple to implement a new rule or action to the logic
it will be not implemented to the game yet, it only is created and tested

Move[EDA-1652] verify if the movement that the player is doing is valid
AC:

- the character that the player is trying to move is of that player
- the direction of the character that the player is trying to move in inside of the board and his limits
- the direction of the character that the player is trying to move in not in another character of the same player
- if does not raise any exception, continue the chain of responsibility

MoveAndDie[[EDA-1663]  a character is landing to another character of the opposite player
AC:

-transfer the treasure (Gold, Diamond) to the cell that it was that character if any
- remove that character that died from the board and the player 
- discover the cell where the opponent character was
- return a correct move
- continue the chain of responsibility if it wasn't a move and die movement