### PR TITLE
untested lines in application/move and application/move_and_die tested

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,11 @@
 
 
+
+
 [run]
 source =
     game
+    application
 
 omit =
     env/*

--- a/application/move.py
+++ b/application/move.py
@@ -30,7 +30,6 @@ class Move(Action):
         if coordinates is False:
             raise noPossibleMoveException()
 
-        # to_row, to_col = coordinates
         # reutilize the friendly fire method for moving to a same player character
         if is_frendly_fire(from_row, from_col, direction, current_player, board):
             raise moveToYourOwnCharPositionException()

--- a/application/move_and_die.py
+++ b/application/move_and_die.py
@@ -18,7 +18,7 @@ class MoveAndDie(Action):
         character_origin_cell: Character = origin_cell.character
 
         # check if there is an opponent character
-        if character_target_cell.player is not None and character_target_cell.player is not current_player:
+        if character_target_cell is not None and character_target_cell.player is not current_player:
             character_origin_cell.transfer_tresaure(origin_cell)
             origin_cell.remove_character()
             board.discover_cell(to_row, to_col, current_player)

--- a/test/test_application_move.py
+++ b/test/test_application_move.py
@@ -15,7 +15,7 @@ from exceptions.personal_exceptions import (
 from game.board import Board
 from parameterized import parameterized
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestMove(unittest.TestCase):
@@ -51,20 +51,21 @@ class TestMove(unittest.TestCase):
                 )
 
     @parameterized.expand([
-        ('NEXT_ACTION', 'execute', 4, 4, WEST)
+        ('next_action_move_and_die', 'get_next_action', 4, 4, WEST)
     ])
     def test_execute_valid_move_continue__the_chain_of_responsability(
         self,
         name_of_the_test_case,
-        execute_pathced,
+        get_next_action_pathced,
         row,
         col,
         direction,
 
     ):
-        self.move.get_next_action = MagicMock(return_value=MoveAndDie)
+        move_n_die = MoveAndDie()
+        self.move.set_next(move_n_die)
         self.board._board = self.scenarios
-        with patch.object(Move, execute_pathced, return_value='_') as patched_method_execute:
+        with patch.object(Move, get_next_action_pathced) as patched_method:
             self.move.execute(
                 row,
                 col,
@@ -72,4 +73,4 @@ class TestMove(unittest.TestCase):
                 self.moving_player,
                 self.board
                 )
-        patched_method_execute.assert_called_once()
+        patched_method.assert_called()

--- a/test/test_application_move_and_die.py
+++ b/test/test_application_move_and_die.py
@@ -1,14 +1,16 @@
-import unittest
-from parameterized import parameterized
-from constans.constans import SOUTH, NORTH
+from application.move_and_die import MoveAndDie
+from application.move import Move
+from constans.constans import SOUTH, NORTH, WEST
 from constans.constants_scores import CORRECT_MOVE
+from parameterized import parameterized
 from game.board import Board
 from game.cell import Cell
 from constans.scenarios import generate_board_for_move_action_test
-from application.move_and_die import MoveAndDie
 from game.gold import Gold
 from game.diamond import Diamond
 from exceptions.personal_exceptions import invalidMoveException
+from unittest.mock import patch
+import unittest
 
 
 class TestMoveAndDie(unittest.TestCase):
@@ -110,3 +112,28 @@ class TestMoveAndDie(unittest.TestCase):
                 self.moving_player,
                 self.board
                 )
+
+    @parameterized.expand([
+        ('NEXT_ACTION', 'get_next_action', 4, 4, WEST)
+    ])
+    def test_execute_valid_move_to_hole_continue_the_chain_of_responsability(
+        self,
+        name_of_the_test_case,
+        get_next_action_pathced,
+        row,
+        col,
+        direction,
+
+    ):
+        move = Move()
+        self.move_n_die.set_next(move)
+        self.board._board = self.scenarios
+        with patch.object(MoveAndDie, get_next_action_pathced) as patched_method:
+            self.move_n_die.execute(
+                row,
+                col,
+                direction,
+                self.moving_player,
+                self.board
+                )
+        patched_method.assert_called()


### PR DESCRIPTION
there were two lines untested, checked by the coverage report, the continuation of the chain of responsibility in application/move.py and application/move_and_die.py , was done, but not tested. now it is.

Also the folder application was added to .coverage folder