### PR TITLE
[MAYOR][EDA-1667] Modify penalize action manager

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -160,8 +160,7 @@ class WumpusGame():
             self.current_player.invalid_moves_count = 0
             self.modify_score(valid_message)
         except invalidMoveException:
-            self.current_player.invalid_moves_count += 1
-            self.modify_score(INVALID_MOVE)
+            self.penalize_player()
 
     def penalize_player(self) -> None:
         self.current_player.penalize()
@@ -277,5 +276,10 @@ class WumpusGame():
         return (False, GAME_OVER_NOT_MET)
 
     def get_current_player_name(self) -> str:
-        if self.remaining_moves > 0:
+        if self.remaining_moves > 0 and self.game_is_active and self.all_player_have_characters():
             return self.current_player.user_name
+        else:
+            return ''
+
+    def all_player_have_characters(self):
+        return self.player_1.characters and self.player_2.characters

--- a/game/manager.py
+++ b/game/manager.py
@@ -76,7 +76,11 @@ class Manager():
         del self.games[game_id]
 
     def check_game_over(self, current_game):
-        if current_game.remaining_moves <= 0 or not current_game.game_is_active:
+        if (
+            current_game.remaining_moves <= 0 or
+            not current_game.game_is_active or
+            not current_game.all_player_have_characters()
+        ):
             self.delete_game_from_manager(current_game.game_id)
             return True
         else:
@@ -104,7 +108,7 @@ class Manager():
             play_data = game.game_over_final_message()
         else:
             play_data = game.generate_response()
-        play_data.update(self.action_data)
+            play_data.update(self.action_data)
         play_data[STATE] = state
         return GameState(
             game.game_id,
@@ -142,7 +146,6 @@ class Manager():
             raise InvalidData()
 
     def process_request(self, game_id: str, api_data: dict) -> GameState:
-
         state = INVALID_STATE
         try:
             current_game = self.find_game(game_id)

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -332,7 +332,7 @@ class TestGame(unittest.TestCase):
         ('shoot discovered opponent', 5, 1000, 8, 8, WEST, 8, 7, 16_100, 110_000, 4, "     "),
         ('shoot covered empty cell', 5, 1000, 8, 8, EAST, 8, 9, 1_100, 110_000, 4, "##F##"),
         ('shoot hole', 5, 1000, 8, 8, NORTH, 7, 8, 1100, 110_000, 4, "  O  "),
-        ('shoot own char', 5, 1000, 8, 8, SOUTH, 9, 8, 900, 110_000, 4, "  B  "),
+        ('shoot own char', 5, 1000, 8, 8, SOUTH, 9, 8, 0, 110_000, 4, "  B  "),
         ('shoot covered opponent', 4, 1000, 4, 4, WEST, 4, 3, 16_100, 110_000, 3, "     "),
         ('shoot discovered empty cell', 3, 1000, 4, 4, EAST, 4, 5, 1100, 110_000, 2, "  F  "),
         ('shoot covered opponent with treasures', 2, 1000, 4, 4, NORTH, 3, 4, 16_100, 30_000, 1, " 2 D "),
@@ -377,7 +377,7 @@ class TestGame(unittest.TestCase):
         ('cell with opponent char',
          4, 4, NORTH, 1000, 3, 4, 11_100, 3, EMPTY_CELL, '  P  ', 5),
         ('cell with own char',
-         4, 4, SOUTH, 1000, 5, 4, 10_900, 4, '  B  ', '  B  ', 5),
+         4, 4, SOUTH, 1000, 5, 4, 10_000, 4, '  B  ', '  B  ', 5),
 
         ('discovered cell with hole carrying treasure',
          8, 8, WEST, 1000, 8, 7, 1_100, 3, ' 1   ', '  O  ', 5),
@@ -487,11 +487,11 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.is_game_over(), message)
 
     @parameterized.expand([
-        ('try to move outside the board to west', 1, MOVE, WEST, 1, -100),
-        ('try to move outside the board north', 1, MOVE, NORTH, 1, -100),
-        ('try to shoot outside the board west', 1, SHOOT, WEST, 1, -100),
-        ('try to shoot outside the board north', 1, SHOOT, NORTH, 1, -100),
-        ('try to shoot without arrows', 0, SHOOT, EAST, 1, -100),
+        ('try to move outside the board to west', 1, MOVE, WEST, 1, -1000),
+        ('try to move outside the board north', 1, MOVE, NORTH, 1, -1000),
+        ('try to shoot outside the board west', 1, SHOOT, WEST, 1, -1000),
+        ('try to shoot outside the board north', 1, SHOOT, NORTH, 1, -1000),
+        ('try to shoot without arrows', 0, SHOOT, EAST, 1, -1000),
     ])
     def test_execute_action_invalid(self, name,
                                     initial_arrows, action, direction,
@@ -512,6 +512,16 @@ class TestGame(unittest.TestCase):
 
         self.assertEqual(current_invalid_moves, expected_invalid_moves)
         self.assertEqual(current_score, expected_score)
+
+    def test_get_current_player_name_else_remaining_moves(self):
+        game = WumpusGame([NAME_USER_1, NAME_USER_2])
+        game.remaining_moves = 0
+        self.assertEqual(game.get_current_player_name(), '')
+
+    def test_get_current_player_name_game_is_active(self):
+        game = WumpusGame([NAME_USER_1, NAME_USER_2])
+        game.game_is_active = False
+        self.assertEqual(game.get_current_player_name(), '')
 
 
 if __name__ == '__main__':

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -62,9 +62,9 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(self.player.arrows, expected_result)
 
     @parameterized.expand([
-        (MOVE, 0, 0, WEST, -100, 1),
-        (SHOOT, 16, 0, SOUTH, -100, 1),
-        (SHOOT, 0, 0, NORTH, -100, 1)
+        (MOVE, 0, 0, WEST, -1000, 1),
+        (SHOOT, 16, 0, SOUTH, -1000, 1),
+        (SHOOT, 0, 0, NORTH, -1000, 1)
     ])
     def test_invalid_moves_count_player_1(
             self,
@@ -89,9 +89,9 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(invalid_moves_count, expected_count)
 
     @parameterized.expand([
-        (MOVE, 0, 16, EAST, -100, 1),
-        (SHOOT, 16, 16, EAST, -100, 1),
-        (SHOOT, 16, 16, SOUTH, -100, 1)
+        (MOVE, 0, 16, EAST, -1000, 1),
+        (SHOOT, 16, 16, EAST, -1000, 1),
+        (SHOOT, 16, 16, SOUTH, -1000, 1)
     ])
     def test_invalid_moves_count_player_2(
             self,


### PR DESCRIPTION
When I play wumpus on the local platform.  I detected that when a game finishes because one player makes 5 mistakes. The manager of Wumpus doesn't change the event of the message sent to the server.  E.G

```
{"event": "your_turn", 
"data": {"result": {"LOSER": "mamerida2013@gmail.com", "WINNER": "asdasdas"}, 
"status": "GAME OVER - Player 1 reached 5 invalid moves in a row", 
"score": {"player_1": 100.0, "player_2": 1000.0}, "winner_side": "P", "turn_token": "3b22c7f9-b63d-41df-8909-2370e70ad0e2", "game_id": "04bcbbca-3f67-11ed-b754-0242ac160004"}}
```

This error happened because in the first step. When a game is over need to send an empty string as current_player to the server.

Also, the manager.py when a player makes a mistake when making a move. updated invalid_moves_score but never checked if the invalid move limit has been reached. And  It sent an incorrect message to the server.

So I modified the raise in execute_action for call penalize_player function that updates invalid move count and if
the limit is reached will change the game state and modify the game score 

