### PR TITLE
[MINOR][EDA-1675] Create initialize responsibility function

### DIFF
--- a/application/action.py
+++ b/application/action.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 
 from application.handler import Handler
+from game.board import Board
+from game.player import Player
 
 
 class Action(Handler):
@@ -15,5 +17,5 @@ class Action(Handler):
         return self._next_handler
 
     @abstractmethod
-    def execute(row, col, direction, current_player, board):
+    def execute(row: int, col: int, direction: str, current_player: Player, board: Board):
         pass

--- a/application/initialize_chain_responsibility.py
+++ b/application/initialize_chain_responsibility.py
@@ -1,0 +1,43 @@
+from application.action import Action
+from application.move import Move
+from application.move_and_die import MoveAndDie
+from application.move_to_empty import MoveToEmpty
+from application.move_to_hole import MoveToHole
+from application.shoot_arrow import ShootArrow
+from application.shoot_and_kill import ShootAndKill
+from application.shoot_to_hole import ShootToHole
+from application.shoot_to_empty_cell import ShootEmptyCell
+from constans.constans import MOVE, SHOOT
+
+
+def initialize_chain_responsibility(action: str) -> Action:
+
+    if action == SHOOT:
+
+        # initialize classes
+        shoot_arrow = ShootArrow()
+        shoot_and_kill = ShootAndKill()
+        shoot_to_hole = ShootToHole()
+        shoot_to_empty_cell = ShootEmptyCell()
+
+        # set chain of responsability
+        shoot_arrow.set_next(shoot_and_kill)
+        shoot_and_kill.set_next(shoot_to_hole)
+        shoot_to_hole.set_next(shoot_to_empty_cell)
+
+        return shoot_arrow
+
+    elif action == MOVE:
+
+        # initialize classes
+        move = Move()
+        move_and_die = MoveAndDie()
+        move_to_hole = MoveToHole()
+        move_to_empty_cell = MoveToEmpty()
+
+        # set chain of responsability
+        move.set_next(move_and_die)
+        move_and_die.set_next(move_to_hole)
+        move_to_hole.set_next(move_to_empty_cell)
+
+        return move

--- a/application/shoot_to_hole.py
+++ b/application/shoot_to_hole.py
@@ -1,6 +1,6 @@
 from application.action import Action
-from constans.constants_scores import CORRECT_MOVE
 from application.utils import target_position_within_bounds
+from constans.constants_scores import CORRECT_MOVE
 from exceptions.personal_exceptions import invalidMoveException
 from game.board import Board
 from game.cell import Cell

--- a/game/board.py
+++ b/game/board.py
@@ -1,12 +1,8 @@
 from dataclasses import dataclass
 import random
 from constans.constans import (
-    EAST,
     FORBIDDEN_HOLE_CELLS,
     INITIAL_POSITIONS,
-    NORTH,
-    SOUTH,
-    WEST,
 )
 from constans.constants_game import (
     GOLD,
@@ -22,19 +18,6 @@ from game.diamond import Diamond
 from game.gold import Gold
 from game.utils import posibles_positions
 from constans.constans import PLAYER_1
-from constans.constants_scores import (
-    ARROW_MISS,
-    CORRECT_MOVE,
-    KILL,
-)
-from exceptions.personal_exceptions import (
-    friendlyFireException,
-    moveToYourOwnCharPositionException,
-    noArrowsAvailableException,
-    noPossibleMoveException,
-    notYourCharacterException,
-    shootOutOfBoundsException,
-)
 from game.player import Player
 
 
@@ -208,94 +191,6 @@ class Board():
             return ((destination_row - (row + 0.1)) ** 2 + (destination_col - col) ** 2) ** (0.5)
         return sorted(positions, key=sorted_key)
 
-    def shoot_arrow(
-        self,
-        row: int,
-        col: int,
-        direction: str,
-        current_player: Player,
-    ) -> str:
-        """
-        Takes a coordenate, a direction and a current player.
-        Returns the string with the result of the actions.
-        In case the shoot kills an enemy returns "KILL".
-        In case the shoot miss an opponent character returns "ARROW_MISS".
-        In case the shoot hit a hole returns "CORRECT_MOVE".
-        In case of an invalid move, raises an "invalidMoveException".
-        """
-        self.there_are_arrows_available(current_player)
-
-        target_row, target_col = self.target_position(row, col, direction)
-        target_cell = self._board[target_row][target_col]
-
-        self.is_not_frendly_fire(target_cell, current_player)
-
-        if (target_cell.character is not None and
-           target_cell.character.player.name != current_player.name):
-            result = self.kill_opp(target_row, target_col, current_player)
-
-        elif target_cell.has_hole:
-            result = self.shoot_hole(target_row, target_col, current_player)
-
-        elif target_cell.character is None:
-            result = self.shoot_miss(target_row, target_col, current_player)
-
-        return result
-
-    def there_are_arrows_available(
-        self,
-        current_player: Player,
-    ) -> None:
-        if current_player.arrows < 1:
-            raise noArrowsAvailableException()
-
-    def is_not_frendly_fire(
-        self,
-        target_cell: Cell,
-        current_player: Player,
-    ) -> None:
-        if (
-            target_cell.character is not None and
-            target_cell.character.player.name == current_player.name
-        ):
-            current_player.arrows -= 1
-            raise friendlyFireException()
-
-    def kill_opp(
-        self,
-        row: int,
-        col: int,
-        current_player: Player,
-    ) -> str:
-        current_player.arrows -= 1
-        cell = self._board[row][col]
-        character_to_kill = cell.character
-        character_to_kill.transfer_tresaure(cell)
-        cell.remove_character()
-        self.discover_cell(row, col, current_player)
-        return KILL
-
-    def shoot_miss(
-        self,
-        row: int,
-        col: int,
-        current_player: Player,
-    ) -> str:
-        # self.discover_cell(row, col, current_player)
-        current_player.arrows -= 1
-        self._board[row][col].arrow += 1
-        return ARROW_MISS
-
-    def shoot_hole(
-        self,
-        row: int,
-        col: int,
-        current_player: Player,
-    ) -> str:
-        self.discover_cell(row, col, current_player)
-        current_player.arrows -= 1
-        return CORRECT_MOVE
-
     def discover_cell(
         self,
         row: int,
@@ -307,91 +202,6 @@ class Board():
             cell.is_discover[0] = True
         else:
             cell.is_discover[1] = True
-
-    def target_position(
-        self,
-        row: int,
-        col: int,
-        direction: str,
-    ) -> "tuple[int, int]":
-        directions = {
-            EAST: (0, 1),
-            SOUTH: (1, 0),
-            WEST: (0, -1),
-            NORTH: (-1, 0)
-        }
-        target_row = row + directions[direction][0]
-        target_col = col + directions[direction][1]
-        if (target_row < 0 or target_row > LARGE - 1
-           or target_col < 0 or target_col > LARGE - 1):
-            raise shootOutOfBoundsException()
-        return (target_row, target_col)
-
-    def move_to_own_character_position(self, current_player, row_to, col_to):
-        ch = self._board[row_to][col_to].character
-        if ch and ch.player == current_player:
-            raise moveToYourOwnCharPositionException()
-
-    def is_a_player_character(self, row, col, current_player):
-        character = self._board[row][col].character
-        return character.player.name == current_player.name if character else False
-
-    def is_valid_move(
-        self,
-        from_row,
-        from_col,
-        to_row,
-        to_col,
-        current_player: Player
-    ):
-        coordinates = (to_row, to_col)
-        if not self.is_a_player_character(from_row, from_col, current_player):
-            raise notYourCharacterException()
-        if (coordinates not in posibles_positions(from_row, from_col)):
-            raise noPossibleMoveException()
-        self.move_to_own_character_position(current_player, to_row, to_col)
-        dictionary = {
-            "from_row": from_row,
-            "from_col": from_col,
-            "to_row": to_row,
-            "to_col": to_col,
-            "player": current_player,
-        }
-        return self.filter_move(dictionary)
-
-    def make_move(self, dictionary):
-        from_row = dictionary["from_row"]
-        from_col = dictionary["from_col"]
-        to_row = dictionary["to_row"]
-        to_col = dictionary["to_col"]
-        current_player = dictionary["player"]
-        new_cell: Cell = self._board[to_row][to_col]
-        old_cel = self._board[from_row][from_col]
-        character: Character = self._board[from_row][from_col].character
-        character.player.arrows += new_cell.arrow
-        new_cell.transfer_tresaure(character)
-        new_cell.arrow = 0
-        new_cell.character = character
-        old_cel.character = None
-        self.discover_cell(to_row, to_col, current_player)
-        return CORRECT_MOVE
-
-    def filter_move(self, dictionary):
-        cell_to = self._board[dictionary["to_row"]][dictionary["to_col"]]
-        current_player = dictionary["player"]
-        character_cel = cell_to.character
-
-        if cell_to.has_hole or self.has_opponent_player(character_cel, current_player):
-            row, col = dictionary["from_row"], dictionary["from_col"]
-            cell = self._board[row][col]
-            char = cell.character
-            self.discover_cell(dictionary["to_row"], dictionary["to_col"], current_player)
-            char.transfer_tresaure(cell)
-            cell.remove_character()
-
-            return CORRECT_MOVE
-        else:
-            return self.make_move(dictionary)
 
     def item_quantity(self, item):
         item_quantity = 0

--- a/game/game.py
+++ b/game/game.py
@@ -1,8 +1,8 @@
+from application.action import Action
+from application.initialize_chain_responsibility import initialize_chain_responsibility
 from constans.constans import (
     JOIN_ROW_BOARD,
     MAXIMUM_INVALID_MOVES,
-    MOVE,
-    SHOOT,
     PLAYER_1,
     INITIAL_POSITION_PLAYER_1,
     INITIAL_POSITION_PLAYER_2,
@@ -38,7 +38,7 @@ from constans.constants_messages import (
 import uuid
 from game.board import Board
 from game.player import Player
-from game.utils import posibles_positions, translate_position
+from game.utils import posibles_positions
 from exceptions.personal_exceptions import (
     invalidMoveException,
 )
@@ -147,16 +147,16 @@ class WumpusGame():
 
         return JOIN_ROW_BOARD.join(user_board)
 
-    def execute_action(self, action, from_row, from_col, direction):
-        to_row, to_col = translate_position(from_row, from_col, direction)
+    def execute_action(self, action: str, from_row: int, from_col: int, direction: str):
         try:
-            if action == MOVE:
-                valid_message = self._board.is_valid_move(from_row, from_col,
-                                                          to_row, to_col,
-                                                          self.current_player)
-            elif action == SHOOT:
-                valid_message = self._board.shoot_arrow(from_row, from_col, direction,
-                                                        self.current_player)
+            action: Action = initialize_chain_responsibility(action)
+            valid_message = action.execute(
+                from_row,
+                from_col,
+                direction,
+                self.current_player,
+                self._board
+            )
             self.current_player.invalid_moves_count = 0
             self.modify_score(valid_message)
         except invalidMoveException:

--- a/game/utils.py
+++ b/game/utils.py
@@ -1,5 +1,4 @@
 from constans.constants_game import LARGE
-from constans.constans import EAST, NORTH, SOUTH, WEST
 
 
 def posibles_positions(row, col):
@@ -20,19 +19,3 @@ def posibles_positions(row, col):
         del (positions['west'])
 
     return list(positions.values())
-
-
-def translate_position(from_row, from_col, direction):
-    if direction == NORTH:
-        to_row = from_row - 1
-        to_col = from_col
-    elif direction == SOUTH:
-        to_row = from_row + 1
-        to_col = from_col
-    elif direction == EAST:
-        to_row = from_row
-        to_col = from_col + 1
-    elif direction == WEST:
-        to_row = from_row
-        to_col = from_col - 1
-    return to_row, to_col

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import unittest
 from unittest.mock import patch
 from parameterized import parameterized
+from application.initialize_chain_responsibility import initialize_chain_responsibility
 from game.diamond import Diamond
 from game.board import Board
 from game.game import WumpusGame
@@ -195,17 +196,15 @@ class TestGame(unittest.TestCase):
         character = Character(game.player_1)
         game.player_1.characters.append(character)
         game._board._board[4][5].character = character
-        dict_move = {
-            "from_col": 5,
-            "from_row": 4,
-            "to_col": 5,
-            "to_row": 5,
-            "player": game.current_player
-        }
+        from_col = 5
+        from_row = 4
+        direction = SOUTH
+        player = game.current_player
+
         gold_before_move = character.gold
         diamonds_before_move = character.diamond
-
-        result = game._board.make_move(dict_move)
+        action = initialize_chain_responsibility(MOVE)
+        result = action.execute(from_row, from_col, direction, player, game._board)
 
         golds_after_move = character.gold
         diamonds_after_move = character.diamond


### PR DESCRIPTION
In `application` directory created the `initialize_chain_responsibility` that:
- Receive an action: `"MOVE"` or `"SHOOT"`
- If the action is `MOVE`: 
         - Instances `Move`, `MoveAndDie`, `MoveToHole`, and `MoveToEmpty` classes 
         - Set the chain of responsibility in this order: Move -> MoveAndDie -> MoveToHole -> MoveToEmpty
         - Return Move (first link of the chain)

- If the action is `SHOOT`: 
         - Instances `Shoot`, `ShootAndKill`, `ShooToHole`, and `ShootToEmptyCell` classes 
         - Set the chain of responsibility in this order: Shoot -> ShootAndKill -> ShooToHole -> ShootToEmptyCell
         - Return Shoot (first link of the chain)

in Game class → the `execute_action` method calls `initialize_chain_responsibility` and executes the action.

Delete all the shoot and move methods from the Board class and their tests, because those methods are implemented with the chain of responsibility. 
