### PR TITLE
[PATCH][EDA-1672] - Change name attribute to side

### DIFF
--- a/application/utils.py
+++ b/application/utils.py
@@ -9,7 +9,7 @@ def is_a_player_character(row, col, current_player: Player, board: Board) -> boo
     cell = board.get_cell(row, col)
     character: Character = cell.character
     if character:
-        return character.player.name == current_player.name
+        return character.player.side == current_player.side
     return False
 
 
@@ -17,7 +17,7 @@ def is_frendly_fire(row, col, direction, current_player: Player, board: Board) -
     target_row, target_col = target_position_within_bounds(row, col, direction)
     target_cell = board.get_cell(target_row, target_col)
     if target_cell.character:
-        return target_cell.character.player.name == current_player.name
+        return target_cell.character.player.side == current_player.side
     return False
 
 

--- a/game/board.py
+++ b/game/board.py
@@ -198,7 +198,7 @@ class Board():
         current_player: Player,
     ) -> None:
         cell = self._board[row][col]
-        if current_player.name == PLAYER_1:
+        if current_player.side == PLAYER_1:
             cell.is_discover[0] = True
         else:
             cell.is_discover[1] = True
@@ -211,4 +211,4 @@ class Board():
         return item_quantity
 
     def has_opponent_player(self, character: Character, current_player: Player) -> bool:
-        return character.player.name != current_player.name if character else False
+        return character.player.side != current_player.side if character else False

--- a/game/cell.py
+++ b/game/cell.py
@@ -29,7 +29,7 @@ class Cell(TreasureHolder):
 
     @property
     def has_player(self):
-        return self.character.player.name if (
+        return self.character.player.side if (
             self.character is not None
             ) else None
 
@@ -54,7 +54,7 @@ class Cell(TreasureHolder):
 
     def _middle_char(self, representation: list):
         if self.character:
-            representation[2] = self.character.player.name
+            representation[2] = self.character.player.side
 
         elif self.has_hole:
             representation[2] = HOLE

--- a/game/game.py
+++ b/game/game.py
@@ -81,7 +81,7 @@ class WumpusGame():
             player_name = self._board._board[p_row][p_col].has_player
             if (
                 player_name is not None
-                and player_name != self.current_player.name
+                and player_name != self.current_player.side
             ):
                 parsed_cell[-1] = "+"
 
@@ -129,7 +129,7 @@ class WumpusGame():
 
     def _parse_cell(self, row: int, col: int) -> str:
         parsed_cell = self._board._board[row][col].to_str(
-            self.current_player.name
+            self.current_player.side
         )
         if '#' not in parsed_cell:
             parsed_cell = self.put_danger_signal(parsed_cell, row, col)
@@ -179,7 +179,7 @@ class WumpusGame():
             "game_active": self.game_is_active,
             "remaining_turns": self.remaining_moves,
             "game_id": self.game_id,
-            "side": self.current_player.name,
+            "side": self.current_player.side,
         }
 
     def generate_response(self):
@@ -198,13 +198,13 @@ class WumpusGame():
 
     def get_winner_side(self, game_over_message):
         winner_dictionary = {
-            GAME_OVER_MESSAGE_1: self.player_2.name,
-            GAME_OVER_MESSAGE_2: self.player_1.name,
+            GAME_OVER_MESSAGE_1: self.player_2.side,
+            GAME_OVER_MESSAGE_2: self.player_1.side,
             GAME_OVER_MESSAGE_3: "DRAW",
-            GAME_OVER_MESSAGE_4: self.player_2.name,
-            GAME_OVER_MESSAGE_5: self.player_1.name,
-            GAME_OVER_MESSAGE_6: self.player_1.name,
-            GAME_OVER_MESSAGE_7: self.player_2.name,
+            GAME_OVER_MESSAGE_4: self.player_2.side,
+            GAME_OVER_MESSAGE_5: self.player_1.side,
+            GAME_OVER_MESSAGE_6: self.player_1.side,
+            GAME_OVER_MESSAGE_7: self.player_2.side,
         }
         return winner_dictionary[game_over_message]
 

--- a/game/player.py
+++ b/game/player.py
@@ -11,9 +11,9 @@ from game.character import Character
 
 class Player():
 
-    def __init__(self, name, user_name):
+    def __init__(self, side, user_name):
         self.user_name = user_name
-        self.name = name
+        self.side = side
         self._score = INITIAL_SCORE
         self.arrows = INITIAL_ARROWS
         self.characters = []

--- a/test/test_character.py
+++ b/test/test_character.py
@@ -17,7 +17,7 @@ class TestCharacter(unittest.TestCase):
         char = Character(Player(player_name, name_user))
         self.assertEqual(char.gold, 0)
         self.assertEqual(char.gold, 0)
-        self.assertEqual(char.player.name, player_name)
+        self.assertEqual(char.player.side, player_name)
 
 
 if __name__ == "__main__":

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -83,8 +83,8 @@ class TestGame(unittest.TestCase):
         self.assertIsNotNone(game._board)
         self.assertIsNotNone(game._board._board[0][0])
         self.assertIsInstance(game._board._board[0][0], Cell)
-        self.assertEqual(game.player_1.name, PLAYER_1)
-        self.assertEqual(game.player_2.name, PLAYER_2)
+        self.assertEqual(game.player_1.side, PLAYER_1)
+        self.assertEqual(game.player_2.side, PLAYER_2)
         self.assertTrue(game)
 
     @parameterized.expand([
@@ -439,7 +439,7 @@ class TestGame(unittest.TestCase):
         actual_player = game.current_player
         actual_remaining_moves = game.remaining_moves
 
-        self.assertEqual(actual_player.name, expected_player)
+        self.assertEqual(actual_player.side, expected_player)
         self.assertEqual(actual_remaining_moves, expected_remainig_moves)
 
     def test_when_a_penalize_is_called_invalid_moves_count_increase(self):

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -37,7 +37,7 @@ class TestPlayer(unittest.TestCase):
         self.player = Player(name, NAME_USER_1)
         self.assertEqual(self.player.arrows, expected_arrows)
         self.assertEqual(self.player.score, expected_score)
-        self.assertEqual(self.player.name, name)
+        self.assertEqual(self.player.side, name)
 
     @parameterized.expand([
         (PLAYER_1, 0, -10000, -10000),


### PR DESCRIPTION
In the current state of wumpus, the player has two attributes: 

user_name: is the email of the bot user

name: is the name of the characters of the player (B or P in the current state)

This generates confusion about which name are we using. In this ticket, we will change the “name” attribute of Player to “side” indicating the side of the board that will also need to change in a future ticket from B, P to L(Left) and R(Right)

AC:

change in player attribute name to side and change ALL THE TESTS that are using it to keep passing