### PR TITLE
[MINOR][EDA-1685] - Add Circle Ci in Wumpus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,86 @@ jobs:
           name: Update CodeClimate coverage report
           command: |
               ./cc-test-reporter after-build --exit-code $?
+  build-and-upload-image:
+    docker:
+      - image: docker:20.10.14-git
+    parameters:
+      app_name:
+        type: string
+        description: Name of the application to build
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache py3-pip
+            pip install awscli
+      - restore_cache:
+          keys:
+            - v1-{{ .Branch }}
+          paths:
+            - /caches/<< parameters.app_name >>.tar
+      - run:
+          name: Load Docker image layer cache
+          command: |
+            set +o pipefail
+            docker load -i /caches/<< parameters.app_name >>.tar | true
+      - run:
+          name: Build application Docker image
+          command: |
+            docker build --cache-from=<< parameters.app_name >> -t << parameters.app_name >> .
+      - run:
+          name: Save Docker image layer cache
+          command: |
+            mkdir -p /caches
+            docker save -o /caches/<< parameters.app_name >>.tar << parameters.app_name >>
+      - save_cache:
+          key: v1-{{ .Branch }}-{{ epoch }}
+          paths:
+            - /caches/<< parameters.app_name >>.tar
+      - deploy:
+          name: Push application Docker image
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              aws ecr-public get-login-password --region us-east-1 \
+                | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+              docker tag << parameters.app_name >> "${ECR_REGISTRY}/<< parameters.app_name >>:${CIRCLE_SHA1}"
+              docker push "${ECR_REGISTRY}/<< parameters.app_name >>:${CIRCLE_SHA1}"
+              docker tag << parameters.app_name >> "${ECR_REGISTRY}/<< parameters.app_name >>:latest"
+              docker push "${ECR_REGISTRY}/<< parameters.app_name >>:latest"
+            fi
+  trigger-main-repo-update:
+    docker:
+      - image: curlimages/curl
+    steps:
+      - run:
+          name: Update main repo
+          command: |
+            curl \
+            -X POST \
+            -H "Authorization: token $MACHINEUSER_GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/evbeda/edagames/dispatches \
+            -d '{"event_type":"update_wumpus"}'
       
 
 workflows:
   main:
     jobs:
       - build-and-test
+      - build-and-upload-image:
+          app_name: edagames-wumpus
+          requires:
+            - build-and-test
+          context:
+            - 'edagames-aws'
+            - 'edagames'
+      - trigger-main-repo-update:
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: main
+          context:
+            - 'edagames'


### PR DESCRIPTION
In order to upload the wumpus docker image to the ECR in AWS Sandbox, it is necessary to configure circle ci to build and upload the image and trigger its update when a change is pushed to the main branch of wumpus.   

So for that, the `build-and-upload-image` and `trigger-main-repo-update` jobs were added in the `config.yml` file inside the `.circleci` directory. 

