### PR TITLE
[MINOR][EDA-1702]Make the user_1 and user_2 randomly assing player_1 and player_2

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -32,12 +32,14 @@ from game.utils import posibles_positions
 from exceptions.personal_exceptions import (
     invalidMoveException,
 )
+import random
 
 
 class WumpusGame():
 
     def __init__(self, users_names) -> None:
         self.game_id = str(uuid.uuid1())
+        random.shuffle(users_names)
         self.player_1 = Player(PLAYER_1, users_names[0])
         self.player_2 = Player(PLAYER_2, users_names[1])
         self._board = Board()

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -206,7 +206,10 @@ class TestGame(unittest.TestCase):
         self.assertEqual(CORRECT_MOVE, result)
 
     def test_generate_data(self):
-        game = patched_game()
+        game = WumpusGame([NAME_USER_1, NAME_USER_2])
+        game.player_1 = Player(PLAYER_1, NAME_USER_1)
+        game.player_2 = Player(PLAYER_2, NAME_USER_2)
+
         game.current_player = game.player_1
         game_id = "1234-5678-9012-3456-7890"
         game.game_id = game_id


### PR DESCRIPTION
As it is now, the game always assigns the player_1 to the user_1 and the player_2 to the user_2, this makes the game dull, because if, I a user, create a challenge I will always be the player_1 

in the creation of the game, need a random shuffle to assign a player_1 and player_2

AC: 

make so that the player_1 and player_2 randomly assign to the user_1 and user_2