### PR TITLE
[PATCH][EDA-1699] - Refactor modify scores method

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -3,9 +3,6 @@ from application.initialize_chain_responsibility import initialize_chain_respons
 
 from constants.constants import (
     CORRECT_MOVE,
-    DEATH,
-    DIAMOND,
-    GET_ITEMS,
     GAME_OVER_MESSAGE_1,
     GAME_OVER_MESSAGE_2,
     GAME_OVER_MESSAGE_3,
@@ -14,7 +11,6 @@ from constants.constants import (
     GAME_OVER_MESSAGE_6,
     GAME_OVER_MESSAGE_7,
     GAME_OVER_NOT_MET,
-    GOLD,
     INITIAL_POSITION_PLAYER_1,
     INITIAL_POSITION_PLAYER_2,
     INVALID_ACTION,
@@ -85,34 +81,14 @@ class WumpusGame():
 
         return "".join(parsed_cell)
 
-    def modify_score(self, event, payload={}):
+    def modify_score(self, event):
         '''
         Functions that modifies the score correspondingly, for players
         involved.
-        Events are DEATH, GET_ITEMS, KILL, CORRECT_MOVE, INVALID_MOVE,
-        TIMEOUT, ARROW_MISS. Payload is a dictionary,
-        which contents varies according to event.
-        For DEATH, Payload is {"character" = characterObject}, the character
-        that dies.
-        For GET_ITEMS, Payload is {"cell" = cellOject}, where cell is the cell
-        where the character is getting into.
-        For KILL, Payload is not needed, BUT, remember to call modify_score()
-        with a DEATH event later, for the killed character.
-        For CORRECT_MOVE or INVALID_MOVE or TIMEOUT, or ARROW_MISS
-        no payload is needed.
+        Events are KILL, CORRECT_MOVE, INVALID_MOVE, ARROW_MISS.
+        For KILL, remember to call modify_score()
         '''
-        if event == GET_ITEMS:
-            cell = payload["cell"]
-            score = cell.gold * SCORES[GOLD] + cell.diamond * SCORES[DIAMOND]
-            self.current_player.update_score(score)
-        elif event == DEATH:
-            # it has to be removed, because this
-            # functionally is done by treasure_treasure method
-            char = payload["character"]
-            score = (char.gold * SCORES[GOLD] +
-                     char.diamond * SCORES[DIAMOND]) * -1
-            char.player.update_score(score)
-        elif event == KILL:
+        if event == KILL:
             self.current_player.update_score(SCORES[CORRECT_MOVE] + SCORES[KILL])
         else:
             self.current_player.update_score(SCORES[event])

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -3,7 +3,6 @@ import unittest
 from unittest.mock import patch
 from parameterized import parameterized
 from application.initialize_chain_responsibility import initialize_chain_responsibility
-from game.diamond import Diamond
 from game.board import Board
 from game.game import WumpusGame
 from constants.constants import (
@@ -24,18 +23,13 @@ from constants.constants import (
     WEST,
     NAME_USER_1,
     NAME_USER_2,
-    DIAMOND,
-    GOLD,
 )
 from game.cell import Cell
 from game.character import Character
-from game.gold import Gold
 from game.player import Player
 from constants.constants import (
     ARROW_MISS,
     CORRECT_MOVE,
-    DEATH,
-    GET_ITEMS,
     INVALID_MOVE,
     KILL,
     SCORES,
@@ -106,36 +100,11 @@ class TestGame(unittest.TestCase):
         game.change_current_player()
         self.assertEqual(game.current_player, game.player_2)
 
-    def test_modify_score_get_items(self):  # testing "Get_Items" event
-        game = patched_game()
-        cell = Cell(2, 4)
-        cell.treasures.append(Gold())
-        cell.treasures.append(Gold())
-        cell.treasures.append(Gold())
-        cell.treasures.append(Diamond())
-        payload = {"cell": cell}
-        game.modify_score(GET_ITEMS, payload)
-        self.assertEqual(game.current_player.score,
-                         (SCORES[GOLD] * 3 + SCORES[DIAMOND] * 1))
-
-    def test_modify_score_death(self):  # testing "Death" event
-        game = patched_game()
-        char = Character(Player(PLAYER_2, NAME_USER_2))
-        game.current_player = char.player
-        char.treasures.append(Gold())
-        char.treasures.append(Gold())
-        char.treasures.append(Gold())
-        char.treasures.append(Gold())
-        payload = {"character": char}
-        game.modify_score(DEATH, payload)
-        self.assertEqual(char.player.score, (SCORES[GOLD] * 4) * -1)
-
     @parameterized.expand([  # test for modify_score() function
         ("KILL", SCORES[KILL] + SCORES[CORRECT_MOVE]),
         ("CORRECT_MOVE", SCORES[CORRECT_MOVE]),
         ("INVALID_MOVE", SCORES[INVALID_MOVE]),
         ("ARROW_MISS", SCORES[ARROW_MISS]),
-        ("TIMEOUT", SCORES[TIMEOUT_SC]),
     ])
     def test_modify_score(self, event, expected):
         game = patched_game()


### PR DESCRIPTION
Deleted `get_items` and `death` from `modify_score method` and their tests, because those functionalities are done with the `transfer_treasures` method from `TreasureHolder` classes (`Cell` and `Character`). 